### PR TITLE
fix: external-dns annotation for allowing multiple domains

### DIFF
--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -375,7 +375,7 @@ var testServices = map[string]*core.Service{
 		},
 	},
 	"annotation-external-dns": {
-		ObjectMeta: meta.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "svc3",
 			Namespace: "ns1",
 			Annotations: map[string]string{
@@ -394,7 +394,7 @@ var testServices = map[string]*core.Service{
 		},
 	},
 	"annotation-external-dns-list1,annotation-external-dns-list2": {
-		ObjectMeta: meta.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "svc3",
 			Namespace: "ns1",
 			Annotations: map[string]string{

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -142,8 +142,11 @@ func TestController(t *testing.T) {
 
 	for index, testObj := range testServices {
 		found, _ := serviceHostnameIndexFunc(testObj)
-		if !isFound(index, found) {
-			t.Errorf("Service key %s not found in index: %v", index, found)
+		indices := strings.Split(index, ",")
+		for _, idx := range indices {
+			if !isFound(strings.TrimSpace(idx), found) {
+				t.Errorf("Service key %s not found in index: %v", idx, found)
+			}
 		}
 		ips := fetchServiceLoadBalancerIPs(testObj.Status.LoadBalancer.Ingress)
 		if len(ips) != 1 {
@@ -358,6 +361,44 @@ var testServices = map[string]*core.Service{
 			Namespace: "ns1",
 			Annotations: map[string]string{
 				"coredns.io/hostname": "annotation",
+			},
+		},
+		Spec: core.ServiceSpec{
+			Type: core.ServiceTypeLoadBalancer,
+		},
+		Status: core.ServiceStatus{
+			LoadBalancer: core.LoadBalancerStatus{
+				Ingress: []core.LoadBalancerIngress{
+					{IP: "192.0.0.3"},
+				},
+			},
+		},
+	},
+	"annotation-external-dns": {
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "svc3",
+			Namespace: "ns1",
+			Annotations: map[string]string{
+				"external-dns.alpha.kubernetes.io/hostname": "annotation-external-dns",
+			},
+		},
+		Spec: core.ServiceSpec{
+			Type: core.ServiceTypeLoadBalancer,
+		},
+		Status: core.ServiceStatus{
+			LoadBalancer: core.LoadBalancerStatus{
+				Ingress: []core.LoadBalancerIngress{
+					{IP: "192.0.0.3"},
+				},
+			},
+		},
+	},
+	"annotation-external-dns-list1,annotation-external-dns-list2": {
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "svc3",
+			Namespace: "ns1",
+			Annotations: map[string]string{
+				"external-dns.alpha.kubernetes.io/hostname": "annotation-external-dns-list1,annotation-external-dns-list2",
 			},
 		},
 		Spec: core.ServiceSpec{


### PR DESCRIPTION
### Issue
External DNS allows for comma separated domains in its spec.

https://github.com/kubernetes-sigs/external-dns/blob/master/docs/annotations/annotations.md#external-dnsalphakubernetesiohostname

This however does not.

### Changes
* Allows for comma separated domains from external-dns
* Separated the check for annotation and domain validation to support multiple domains more gracefully
* Add tests for external-dns
* Add tests for comma separated external-dns

### Testing
* We are currently using this as is, however you can test by providing the external-dns annotation a comma separated list and checking the logs on the pod.
* Theres unit tests

### Original PR
https://github.com/ori-edge/k8s_gateway/pull/317