### PR TITLE
feat: add support for resolving records for resources with wildcard hostnames

### DIFF
--- a/gateway_test.go
+++ b/gateway_test.go
@@ -226,6 +226,20 @@ var tests = []test.Case{
 			test.A("dns1.kube-system.example.com.   60  IN  A   192.0.1.53"),
 		},
 	},
+	// Lookup that relies on a wildcard | Test 18
+	{
+		Qname: "not-explicitly-defined-label.wildcard.example.com.", Qtype: dns.TypeA, Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("not-explicitly-defined-label.wildcard.example.com. 60  IN  A   192.0.0.6"),
+		},
+	},
+	// Lookup with a matching wildcard but a more specific entry | Test 19
+	{
+		Qname: "specific-subdomain.wildcard.example.com.", Qtype: dns.TypeA, Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("specific-subdomain.wildcard.example.com. 60  IN  A   192.0.0.7"),
+		},
+	},
 }
 
 var testsFallthrough = []FallthroughCase{
@@ -271,11 +285,13 @@ func testServiceLookup(keys []string) (results []netip.Addr) {
 }
 
 var testIngressIndexes = map[string][]netip.Addr{
-	"domain.example.com":    {netip.MustParseAddr("192.0.0.1")},
-	"svc2.ns1.example.com":  {netip.MustParseAddr("192.0.0.2")},
-	"example.com":           {netip.MustParseAddr("192.0.0.3")},
-	"shadow.example.com":    {netip.MustParseAddr("192.0.0.4")},
-	"shadow-vs.example.com": {netip.MustParseAddr("192.0.0.5")},
+	"domain.example.com":                      {netip.MustParseAddr("192.0.0.1")},
+	"svc2.ns1.example.com":                    {netip.MustParseAddr("192.0.0.2")},
+	"example.com":                             {netip.MustParseAddr("192.0.0.3")},
+	"shadow.example.com":                      {netip.MustParseAddr("192.0.0.4")},
+	"shadow-vs.example.com":                   {netip.MustParseAddr("192.0.0.5")},
+	"*.wildcard.example.com":                  {netip.MustParseAddr("192.0.0.6")},
+	"specific-subdomain.wildcard.example.com": {netip.MustParseAddr("192.0.0.7")},
 }
 
 func testIngressLookup(keys []string) (results []netip.Addr) {


### PR DESCRIPTION
Some resources, such as HTTPRoutes, can specify wildcard hostnames. Currently, these values are loaded exactly as-is into the indexer for DNS resolution. As a result, lookups for subdomains matching these wildcard values always fail. This PR allows for resolving these queries, if a more specific record is not specified on another resource.

In short, given these resources:
```yaml
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: s3-gateway
spec:
  hostnames:
    - "*.s3.my.domain.name"
    - s3.my.domain.name
  parentRefs:
    # IP address 1.2.3.4
    - name: my-gateway
      namespace: networking
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: s3-gateway-other
spec:
  hostnames:
    - bucket-3.s3.my.domain.name
  parentRefs:
    # IP address 5.6.7.8
    - name: my-other-gateway
      namespace: networking
```

The following queries can now be resolved:
- s3.my.domain.name: 1.2.3.4 (only this one can be resolved currently)
- bucket-1.s3.my.domain.name: 1.2.3.4
- bucket-2.s3.my.domain.name: 1.2.3.4
- bucket-3.s3.my.domain.name: 5.6.7.8