### PR TITLE
bug(chart): add default value to watchedResources

### DIFF
--- a/charts/k8s-gateway/Chart.yaml
+++ b/charts/k8s-gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-gateway
 description: A Helm chart for the k8s_gateway CoreDNS plugin
 type: application
-version: 3.1.3
+version: 3.1.4
 appVersion: 1.2.0
 maintainers:
   - url: https://github.com/samip5
@@ -10,4 +10,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Updated app version
+      description: Set default value for watchedResources to ["Ingress", "Service"]

--- a/charts/k8s-gateway/README.md
+++ b/charts/k8s-gateway/README.md
@@ -10,7 +10,7 @@ The following table lists the configurable parameters of the k8s_gateway chart a
 | -------------------------------- | ----------------------------------------------------------------------------------------- | --------------------- |
 | `domain`                         | Delegated domain(s)                                                                       |                       |
 | `customLabels`                   | Labels to apply to all resources                                                          | `{}`                  |
-| `watchedResources`               | Default resources to watch, e.g. `watchedResources: ["Ingress"]`                          | `["Ingress", "Service"]`|
+| `watchedResources`               | Resources to watch, e.g. `watchedResources: ["Ingress"]`                                  | `["Ingress", "Service"]`|
 | `filters.ingressClasses`         | Filter Ingress resources by their IngressClassName property                               | `[]`                  |
 | `filters.gatewayClasses`         | Filter Gateway resources by their GatewayClassName property                               | `[]`                  |
 | `fallthrough.enabled`            | Enable fallthrough support                                                                | `false`               |
@@ -19,12 +19,12 @@ The following table lists the configurable parameters of the k8s_gateway chart a
 | `dnsChallenge.enabled`           | Optional configuration option for DNS01 challenge                                         | `false`               |
 | `dnsChallenge.domain`            | See: <https://cert-manager.io/docs/configuration/acme/dns01/>                             | `dns01.clouddns.com`  |
 | `extraZonePlugins`               | Optional extra plugins to be added to the zone, e.g. "forward . /etc/resolv.conf"         | `""`                  |
-| `image.registry`                 | Image registry                                                                            | `quay.io`             |
-| `image.repository`               | Image repository                                                                          | `oriedge/k8s_gateway` |
+| `image.registry`                 | Image registry                                                                            | `ghcr.io`             |
+| `image.repository`               | Image repository                                                                          | `k8s-gateway/k8s_gateway` |
 | `image.tag`                      | Image tag                                                                                 | `latest`              |
 | `image.pullPolicy`               | Image pull policy                                                                         | `Always`              |
-| `podSecurityContext`             |  Set Security Context for Pod                                                             | `{}`                  |
-| `securityContext`                |  Set Security Context for the container                                                   | `{}`                  |
+| `podSecurityContext`             | Set Security Context for Pod                                                              | `{}`                  |
+| `securityContext`                | Set Security Context for the container                                                    | `{}`                  |
 | `nodeSelector`                   | Node labels for pod assignment                                                            | `{}`                  |
 | `tolerations`                    | Use to schedule on node taint to be not schedulable                                       | `[]`                  |
 | `topologySpreadConstraints`      | Use topology spread constraints to control how Pods are spread across your cluster        | `[]`                  |

--- a/charts/k8s-gateway/README.md
+++ b/charts/k8s-gateway/README.md
@@ -10,7 +10,7 @@ The following table lists the configurable parameters of the k8s_gateway chart a
 | -------------------------------- | ----------------------------------------------------------------------------------------- | --------------------- |
 | `domain`                         | Delegated domain(s)                                                                       |                       |
 | `customLabels`                   | Labels to apply to all resources                                                          | `{}`                  |
-| `watchedResources`               | Limit what kind of resources to watch, e.g. `watchedResources: ["Ingress"]`               | `[]`                  |
+| `watchedResources`               | Default resources to watch, e.g. `watchedResources: ["Ingress"]`                          | `["Ingress", "Service"]`|
 | `filters.ingressClasses`         | Filter Ingress resources by their IngressClassName property                               | `[]`                  |
 | `filters.gatewayClasses`         | Filter Gateway resources by their GatewayClassName property                               | `[]`                  |
 | `fallthrough.enabled`            | Enable fallthrough support                                                                | `false`               |

--- a/charts/k8s-gateway/tests/rbac_test.yaml
+++ b/charts/k8s-gateway/tests/rbac_test.yaml
@@ -2,6 +2,100 @@
 suite: RBAC
 
 tests:
+  - it: Should render RBAC for Ingress and Service
+    set:
+      domain: example.com
+    template: templates/rbac.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: ClusterRole
+        documentIndex: 0
+      - isKind:
+          of: ClusterRoleBinding
+        documentIndex: 1
+      - contains:
+          path: rules[0].apiGroups
+          content: apiextensions.k8s.io
+        documentIndex: 0
+      - contains:
+          path: rules[0].resources
+          content: customresourcedefinitions
+        documentIndex: 0
+      - contains:
+          path: rules[0].verbs
+          content: get
+        documentIndex: 0
+      - contains:
+          path: rules[0].verbs
+          content: list
+        documentIndex: 0
+      - contains:
+          path: rules[0].verbs
+          content: watch
+        documentIndex: 0
+      - contains:
+          path: rules[1].resources
+          content: services
+        documentIndex: 0
+      - contains:
+          path: rules[1].resources
+          content: namespaces
+        documentIndex: 0
+      - contains:
+          path: rules[1].verbs
+          content: list
+        documentIndex: 0
+      - contains:
+          path: rules[1].verbs
+          content: watch
+        documentIndex: 0
+      - contains:
+          path: rules[2].resources
+          content: ingresses
+        documentIndex: 0
+      - contains:
+          path: rules[2].verbs
+          content: list
+        documentIndex: 0
+      - contains:
+          path: rules[2].verbs
+          content: watch
+        documentIndex: 0
+
+  - it: Should render RBAC for DNSEndpoint
+    set:
+      domain: example.com
+      watchedResources:
+        - DNSEndpoint
+    template: templates/rbac.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: ClusterRole
+        documentIndex: 0
+      - isKind:
+          of: ClusterRoleBinding
+        documentIndex: 1
+      - contains:
+          path: rules[0].apiGroups
+          content: apiextensions.k8s.io
+        documentIndex: 0
+      - contains:
+          path: rules[1].apiGroups
+          content: externaldns.k8s.io
+        documentIndex: 0
+      - contains:
+          path: rules[1].resources
+          content: dnsendpoints
+        documentIndex: 0
+      - contains:
+          path: rules[2].resources
+          content: dnsendpoints/status
+        documentIndex: 0
+
   - it: Should fail if watchedResources is empty
     set:
       domain: example.com

--- a/charts/k8s-gateway/values.yaml
+++ b/charts/k8s-gateway/values.yaml
@@ -17,7 +17,7 @@ ttl: 300
 resources: {}
 
 # Limit what kind of resources to watch, e.g. watchedResources: ["Ingress"]
-watchedResources: []
+watchedResources: ["Ingress", "Service"]
 
 filters:
   ingressClasses: []


### PR DESCRIPTION
Empty `watchedResources` failed in a recent update to ensure that the user properly installs CRDs.

Closes #73
Caused by #11 

You can search and add all the resources to `watchedResources`, but RBAC won't understand the ones using CRDs.
This is a proposed fix, ensuring that at the very minimum, `Services` and `Ingresses` are monitored.

It will still error out if the list is _explicitly_ empty if there's nothing to watch. 
it should not "limit" to what's in the list. (previous behavior)