### PR TITLE
TXT Support

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -49,11 +49,15 @@ helm_remote('ingress-nginx',
 # Backend deployment for testing
 k8s_yaml('./test/backend.yml')
 
-k8s_yaml('https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/experimental-install.yaml')
+gateway_api_crd_yaml = local('./test/get-gateway-api-crds-for-tilt.sh')
+k8s_yaml(gateway_api_crd_yaml)
+
+dnsendpoint_crd_yaml = local('./test/get-dnsendpoint-crds-for-tilt.sh')
+k8s_yaml(dnsendpoint_crd_yaml)
 
 k8s_kind('HTTPRoute', api_version='gateway.networking.k8s.io/v1')
 k8s_kind('TLSRoute', api_version='gateway.networking.k8s.io/v1alpha2')
-k8s_kind('GRPCRoute', api_version='gateway.networking.k8s.io/v1alpha2')
+k8s_kind('GRPCRoute', api_version='gateway.networking.k8s.io/v1')
 k8s_kind('Gateway', api_version='gateway.networking.k8s.io/v1')
 k8s_yaml('./test/gateway-api/resources.yml')
 k8s_yaml('./test/gatewayclasses.yaml')

--- a/apex.go
+++ b/apex.go
@@ -48,6 +48,10 @@ func (gw *Gateway) serveSubApex(state request.Request) (int, error) {
 				if rr.Header().Rrtype == dns.TypeAAAA {
 					m.Answer = append(m.Answer, rr)
 				}
+			case dns.TypeTXT:
+				if rr.Header().Rrtype == dns.TypeTXT {
+					m.Answer = append(m.Answer, rr)
+				}
 			}
 		}
 

--- a/apex_dual_test.go
+++ b/apex_dual_test.go
@@ -2,7 +2,6 @@ package gateway
 
 import (
 	"context"
-	"net/netip"
 	"testing"
 
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
@@ -14,19 +13,19 @@ import (
 
 func setupEmptyLookupFuncs(gw *Gateway) {
 	if resource := gw.lookupResource("HTTPRoute"); resource != nil {
-		resource.lookup = func(_ []string) []netip.Addr { return []netip.Addr{} }
+		resource.lookup = func(_ []string) map[string][]string { return map[string][]string{} }
 	}
 	if resource := gw.lookupResource("TLSRoute"); resource != nil {
-		resource.lookup = func(_ []string) []netip.Addr { return []netip.Addr{} }
+		resource.lookup = func(_ []string) map[string][]string { return map[string][]string{} }
 	}
 	if resource := gw.lookupResource("GRPCRoute"); resource != nil {
-		resource.lookup = func(_ []string) []netip.Addr { return []netip.Addr{} }
+		resource.lookup = func(_ []string) map[string][]string { return map[string][]string{} }
 	}
 	if resource := gw.lookupResource("Ingress"); resource != nil {
-		resource.lookup = func(_ []string) []netip.Addr { return []netip.Addr{} }
+		resource.lookup = func(_ []string) map[string][]string { return map[string][]string{} }
 	}
 	if resource := gw.lookupResource("Service"); resource != nil {
-		resource.lookup = func(_ []string) []netip.Addr { return []netip.Addr{} }
+		resource.lookup = func(_ []string) map[string][]string { return map[string][]string{} }
 	}
 }
 

--- a/gateway.go
+++ b/gateway.go
@@ -368,9 +368,7 @@ func (gw *Gateway) TXT(name string, results []string) (records []dns.RR) {
 	for _, result := range results {
 		if _, ok := dup[result]; !ok {
 			dup[result] = struct{}{}
-			var resultslice []string
-			resultslice = append(resultslice, result)
-			records = append(records, &dns.TXT{Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeTXT, Class: dns.ClassINET, Ttl: gw.ttlLow}, Txt: resultslice})
+			records = append(records, &dns.TXT{Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeTXT, Class: dns.ClassINET, Ttl: gw.ttlLow}, Txt: split255(result)})
 		}
 	}
 
@@ -420,4 +418,24 @@ func stripClosingDot(s string) string {
 		return strings.TrimSuffix(s, ".")
 	}
 	return s
+}
+
+// src: https://github.com/coredns/coredns/blob/0aee758833cabb1ec89756a698c52b83bbbdc587/plugin/etcd/msg/service.go#L145
+// Split255 splits a string into 255 byte chunks.
+func split255(s string) []string {
+	if len(s) < 255 {
+		return []string{s}
+	}
+	sx := []string{}
+	p, i := 0, 255
+	for {
+		if i > len(s) {
+			sx = append(sx, s[p:])
+			break
+		}
+		sx = append(sx, s[p:i])
+		p, i = p+255, i+255
+	}
+
+	return sx
 }

--- a/gateway.go
+++ b/gateway.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"net/netip"
 	"strings"
 
 	"github.com/coredns/coredns/plugin"
@@ -13,7 +12,7 @@ import (
 	"github.com/miekg/dns"
 )
 
-type lookupFunc func(indexKeys []string) []netip.Addr
+type lookupFunc func(indexKeys []string) map[string][]string
 
 type resourceWithIndex struct {
 	name   string
@@ -30,7 +29,7 @@ var staticResources = []*resourceWithIndex{
 	{name: "DNSEndpoint", lookup: noop},
 }
 
-var noop lookupFunc = func([]string) (result []netip.Addr) { return }
+var noop lookupFunc = func([]string) (result map[string][]string) { return }
 
 var (
 	ttlDefault        = uint32(60)
@@ -159,29 +158,17 @@ func (gw *Gateway) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 	log.Debugf("computed response addresses %v", addrs)
 
 	// Fall through if no host matches
-	if len(addrs) == 0 && gw.Fall.Through(qname) {
+	if len(addrs["A"]) == 0 && len(addrs["AAAA"]) == 0 && len(addrs["TXT"]) == 0 && gw.Fall.Through(qname) {
 		return plugin.NextOrFailure(gw.Name(), gw.Next, ctx, w, r)
 	}
 
 	m := new(dns.Msg)
 	m.SetReply(state.Req)
 
-	var ipv4Addrs []netip.Addr
-	var ipv6Addrs []netip.Addr
-
-	for _, addr := range addrs {
-		if addr.Is4() {
-			ipv4Addrs = append(ipv4Addrs, addr)
-		}
-		if addr.Is6() {
-			ipv6Addrs = append(ipv6Addrs, addr)
-		}
-	}
-
 	switch state.QType() {
 	case dns.TypeA:
 
-		if len(ipv4Addrs) == 0 {
+		if len(addrs["A"]) == 0 {
 
 			if !isRootZoneQuery {
 				// No match, return NXDOMAIN
@@ -192,11 +179,12 @@ func (gw *Gateway) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 
 		} else {
 
-			m.Answer = gw.A(state.Name(), ipv4Addrs)
+			m.Answer = gw.A(state.Name(), addrs["A"])
 		}
+
 	case dns.TypeAAAA:
 
-		if len(ipv6Addrs) == 0 {
+		if len(addrs["AAAA"]) == 0 {
 
 			if !isRootZoneQuery {
 				// No match, return NXDOMAIN
@@ -204,7 +192,7 @@ func (gw *Gateway) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 			}
 
 			// as per rfc4074 #3
-			if len(ipv4Addrs) > 0 {
+			if len(addrs["A"]) > 0 {
 				m.Rcode = dns.RcodeSuccess
 			}
 
@@ -212,7 +200,23 @@ func (gw *Gateway) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 
 		} else {
 
-			m.Answer = gw.AAAA(state.Name(), ipv6Addrs)
+			m.Answer = gw.AAAA(state.Name(), addrs["AAAA"])
+		}
+
+	case dns.TypeTXT:
+
+		if len(addrs["TXT"]) == 0 {
+
+			if !isRootZoneQuery {
+				// No match, return NXDOMAIN
+				m.Rcode = dns.RcodeNameError
+			}
+
+			m.Ns = []dns.RR{gw.soa(state)}
+
+		} else {
+
+			m.Answer = gw.A(state.Name(), addrs["TXT"])
 		}
 
 	case dns.TypeSOA:
@@ -298,13 +302,33 @@ func (gw *Gateway) toWildcardQName(qName, zone string) string {
 
 // Gets the set of addresses associated with the first set of index keys
 // that is in the indexer.
-func (gw *Gateway) getMatchingAddresses(indexKeySets [][]string) []netip.Addr {
+func (gw *Gateway) getMatchingAddresses(indexKeySets [][]string) map[string][]string {
 	// Iterate over supported resources and lookup DNS queries
 	// Stop once we've found at least one match
 	for _, indexKeys := range indexKeySets {
 		for _, resource := range gw.Resources {
 			addrs := resource.lookup(indexKeys)
-			if len(addrs) > 0 {
+
+			if addrs == nil {
+				addrs = make(map[string][]string, 0)
+			}
+			if addrs["A"] == nil {
+				addrs["A"] = make([]string, 0)
+			}
+			if addrs["AAAA"] == nil {
+				addrs["AAAA"] = make([]string, 0)
+			}
+			if addrs["TXT"] == nil {
+				addrs["TXT"] = make([]string, 0)
+			}
+
+			if len(addrs["A"]) > 0 {
+				return addrs
+			}
+			if len(addrs["AAAA"]) > 0 {
+				return addrs
+			}
+			if len(addrs["TXT"]) > 0 {
 				return addrs
 			}
 		}
@@ -317,40 +341,60 @@ func (gw *Gateway) getMatchingAddresses(indexKeySets [][]string) []netip.Addr {
 func (gw *Gateway) Name() string { return thisPlugin }
 
 // A does the A-record lookup in ingress indexer
-func (gw *Gateway) A(name string, results []netip.Addr) (records []dns.RR) {
+func (gw *Gateway) A(name string, results []string) (records []dns.RR) {
 	dup := make(map[string]struct{})
 	for _, result := range results {
-		if _, ok := dup[result.String()]; !ok {
-			dup[result.String()] = struct{}{}
-			records = append(records, &dns.A{Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: gw.ttlLow}, A: net.ParseIP(result.String())})
+		if _, ok := dup[result]; !ok {
+			dup[result] = struct{}{}
+			records = append(records, &dns.A{Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: gw.ttlLow}, A: net.ParseIP(result)})
 		}
 	}
 	return records
 }
 
-func (gw *Gateway) AAAA(name string, results []netip.Addr) (records []dns.RR) {
+func (gw *Gateway) AAAA(name string, results []string) (records []dns.RR) {
 	dup := make(map[string]struct{})
 	for _, result := range results {
-		if _, ok := dup[result.String()]; !ok {
-			dup[result.String()] = struct{}{}
-			records = append(records, &dns.AAAA{Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: gw.ttlLow}, AAAA: net.ParseIP(result.String())})
+		if _, ok := dup[result]; !ok {
+			dup[result] = struct{}{}
+			records = append(records, &dns.AAAA{Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: gw.ttlLow}, AAAA: net.ParseIP(result)})
 		}
 	}
+	return records
+}
+
+func (gw *Gateway) TXT(name string, results []string) (records []dns.RR) {
+	dup := make(map[string]struct{})
+	for _, result := range results {
+		if _, ok := dup[result]; !ok {
+			dup[result] = struct{}{}
+			var resultslice []string
+			resultslice = append(resultslice, result)
+			records = append(records, &dns.TXT{Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeTXT, Class: dns.ClassINET, Ttl: gw.ttlLow}, Txt: resultslice})
+		}
+	}
+
 	return records
 }
 
 // SelfAddress returns the address of the local k8s_gateway service
 func (gw *Gateway) SelfAddress(state request.Request) (records []dns.RR) {
 
-	var addrs1, addrs2 []netip.Addr
+	var addrs1, addrs2 []string
 	for _, resource := range gw.Resources {
 		results := resource.lookup([]string{gw.apex})
-		if len(results) > 0 {
-			addrs1 = append(addrs1, results...)
+		if len(results["A"]) > 0 {
+			addrs1 = append(addrs1, results["A"]...)
+		}
+		if len(results["AAAA"]) > 0 {
+			addrs1 = append(addrs1, results["AAAA"]...)
 		}
 		results = resource.lookup([]string{gw.secondNS})
-		if len(results) > 0 {
-			addrs2 = append(addrs2, results...)
+		if len(results["A"]) > 0 {
+			addrs2 = append(addrs2, results["A"]...)
+		}
+		if len(results["AAAA"]) > 0 {
+			addrs2 = append(addrs2, results["AAAA"]...)
 		}
 	}
 

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -3,7 +3,6 @@ package gateway
 import (
 	"context"
 	"errors"
-	"net/netip"
 	"strings"
 	"testing"
 
@@ -116,6 +115,7 @@ var tests = []test.Case{
 		Qname: "svc1.ns1.example.com.", Qtype: dns.TypeA, Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.A("svc1.ns1.example.com.   60  IN  A   192.0.1.1"),
+			test.A("svc1.ns1.example.com.   60  IN  A   192.0.1.2"),
 		},
 	},
 	// Existing Ingress | Test 1
@@ -186,6 +186,7 @@ var tests = []test.Case{
 		Qname: "svC1.Ns1.exAmplE.Com.", Qtype: dns.TypeA, Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.A("svc1.ns1.example.com.   60  IN  A   192.0.1.1"),
+			test.A("svc1.ns1.example.com.   60  IN  A   192.0.1.2"),
 		},
 	},
 	// basic gateway API lookup | Test 13
@@ -240,6 +241,27 @@ var tests = []test.Case{
 			test.A("specific-subdomain.wildcard.example.com. 60  IN  A   192.0.0.7"),
 		},
 	},
+	// Existing Endpoint | Test 1
+	{
+		Qname: "domain.endpoint.example.com.", Qtype: dns.TypeA, Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("domain.endpoint.example.com. 60  IN  A   192.0.4.1"),
+		},
+	},
+	// Existing Endpoint | Test 2
+	{
+		Qname: "endpoint.example.com.", Qtype: dns.TypeA, Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("endpoint.example.com. 60  IN  A   192.0.4.4"),
+		},
+	},
+	// Existing Endpoint | TXT record
+	{
+		Qname: "endpoint.example.com.", Qtype: dns.TypeTXT, Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.TXT("endpoint.example.com. 60  IN  A   challenge"),
+		},
+	},
 }
 
 var testsFallthrough = []FallthroughCase{
@@ -270,57 +292,132 @@ var testsFallthrough = []FallthroughCase{
 	},
 }
 
-var testServiceIndexes = map[string][]netip.Addr{
-	"svc1.ns1":         {netip.MustParseAddr("192.0.1.1"), netip.MustParseAddr("fd12:3456:789a:1::")},
-	"svc2.ns1":         {netip.MustParseAddr("192.0.1.2")},
+var testServiceIndexes = map[string]map[string][]string{
+	"svc1.ns1":         {
+		"A": {
+			"192.0.1.1",
+			"192.0.1.2",
+		},
+		"AAAA": {
+			"fd12:3456:789a:1::",
+		},
+	},
+	"svc2.ns1":         {
+		"A": {
+			"192.0.1.3",
+		},
+	},
 	"svc3.ns1":         {},
-	"dns1.kube-system": {netip.MustParseAddr("192.0.1.53")},
+	"dns1.kube-system": {
+		"A": {
+			"192.0.1.53",
+		},
+	},
 }
 
-func testServiceLookup(keys []string) (results []netip.Addr) {
+func testServiceLookup(keys []string) (results map[string][]string) {
 	for _, key := range keys {
-		results = append(results, testServiceIndexes[strings.ToLower(key)]...)
+
+		var fetchedResults map[string][]string
+		fetchedResults = testServiceIndexes[strings.ToLower(key)]
+		results = appenddnsResults(results, fetchedResults)
 	}
 	return results
 }
 
-var testIngressIndexes = map[string][]netip.Addr{
-	"domain.example.com":                      {netip.MustParseAddr("192.0.0.1")},
-	"svc2.ns1.example.com":                    {netip.MustParseAddr("192.0.0.2")},
-	"example.com":                             {netip.MustParseAddr("192.0.0.3")},
-	"shadow.example.com":                      {netip.MustParseAddr("192.0.0.4")},
-	"shadow-vs.example.com":                   {netip.MustParseAddr("192.0.0.5")},
-	"*.wildcard.example.com":                  {netip.MustParseAddr("192.0.0.6")},
-	"specific-subdomain.wildcard.example.com": {netip.MustParseAddr("192.0.0.7")},
+var testIngressIndexes = map[string]map[string][]string{
+	"domain.example.com":                      {
+		"A": {
+			"192.0.0.1",
+		},
+	},
+	"svc2.ns1.example.com":                    {
+		"A": {
+			"192.0.0.2",
+		},
+	},
+	"example.com":                             {
+		"A": {
+			"192.0.0.3",
+		},
+	},
+	"shadow.example.com":                      {
+		"A": {
+			"192.0.0.4",
+		},
+	},
+	"shadow-vs.example.com":                   {
+		"A": {
+			"192.0.0.5",
+		},
+	},
+	"*.wildcard.example.com":                  {
+		"A": {
+			"192.0.0.6",
+		},
+	},
+	"specific-subdomain.wildcard.example.com": {
+		"A": {
+			"192.0.0.7",
+		},
+	},
 }
 
-func testIngressLookup(keys []string) (results []netip.Addr) {
+func testIngressLookup(keys []string) (results map[string][]string) {
 	for _, key := range keys {
-		results = append(results, testIngressIndexes[strings.ToLower(key)]...)
+
+		var fetchedResults map[string][]string
+		fetchedResults = testIngressIndexes[strings.ToLower(key)]
+		results = appenddnsResults(results, fetchedResults)
 	}
 	return results
 }
 
-var testRouteIndexes = map[string][]netip.Addr{
-	"domain.gw.example.com": {netip.MustParseAddr("192.0.2.1")},
-	"shadow.example.com":    {netip.MustParseAddr("192.0.2.4")},
+var testRouteIndexes = map[string]map[string][]string{
+	"domain.gw.example.com": {
+		"A": {
+			"192.0.2.1",
+		},
+	},
+	"shadow.example.com":    {
+		"A": {
+			"192.0.2.4",
+		},
+	},
 }
 
-func testRouteLookup(keys []string) (results []netip.Addr) {
+func testRouteLookup(keys []string) (results map[string][]string) {
 	for _, key := range keys {
-		results = append(results, testRouteIndexes[strings.ToLower(key)]...)
+
+		var fetchedResults map[string][]string
+		fetchedResults = testRouteIndexes[strings.ToLower(key)]
+		results = appenddnsResults(results, fetchedResults)
 	}
 	return results
 }
 
-var testDNSEndpointIndexes = map[string][]netip.Addr{
-	"domain.endpoint.example.com": {netip.MustParseAddr("192.0.4.1")},
-	"endpoint.example.com":        {netip.MustParseAddr("192.0.4.4")},
+var testDNSEndpointIndexes = map[string]map[string][]string{
+	"domain.endpoint.example.com": {
+		"A": {
+			"192.0.4.1",
+		},
+	},
+	"endpoint.example.com":        {
+		"A": {
+			"192.0.4.4",
+		},
+		"TXT": {
+			"challenge",
+		},
+	},
 }
 
-func testDNSEndpointLookup(keys []string) (results []netip.Addr) {
+func testDNSEndpointLookup(keys []string) (results map[string][]string) {
 	for _, key := range keys {
-		results = append(results, testDNSEndpointIndexes[strings.ToLower(key)]...)
+
+		var fetchedResults map[string][]string
+		fetchedResults = testDNSEndpointIndexes[strings.ToLower(key)]
+		results = appenddnsResults(results, fetchedResults)
 	}
 	return results
 }

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -523,8 +523,12 @@ func checkDomainValid(domain string) bool {
 	return false
 }
 
-func lookupServiceIndex(ctrl cache.SharedIndexInformer) func([]string) []netip.Addr {
-	return func(indexKeys []string) (result []netip.Addr) {
+func lookupServiceIndex(ctrl cache.SharedIndexInformer) func([]string) map[string][]string {
+	return func(indexKeys []string) (result map[string][]string) {
+		if result == nil {
+			result = make(map[string][]string, 0)
+		}
+
 		var objs []interface{}
 		for _, key := range indexKeys {
 			obj, _ := ctrl.GetIndexer().ByIndex(serviceHostnameIndex, strings.ToLower(key))
@@ -536,20 +540,38 @@ func lookupServiceIndex(ctrl cache.SharedIndexInformer) func([]string) []netip.A
 
 			if len(service.Spec.ExternalIPs) > 0 {
 				for _, ip := range service.Spec.ExternalIPs {
-					result = append(result, netip.MustParseAddr(ip))
+					addr, err := netip.ParseAddr(ip)
+					if err != nil {
+						continue
+					}
+
+					if addr.Is4() {
+						if result["A"] == nil {
+							result["A"] = make([]string, 0)
+						}
+						result["A"] = append(result["A"], addr.String())
+					}
+					if addr.Is6() {
+						if result["AAAA"] == nil {
+							result["AAAA"] = make([]string, 0)
+						}
+						result["AAAA"] = append(result["AAAA"], addr.String())
+					}
 				}
 				// in case externalIPs are defined, ignoring status field completely
 				return
 			}
 
-			result = append(result, fetchServiceLoadBalancerIPs(service.Status.LoadBalancer.Ingress)...)
+			var fetchedResults map[string][]string
+			fetchedResults = fetchServiceLoadBalancerIPs(service.Status.LoadBalancer.Ingress)
+			result = appenddnsResults(result, fetchedResults)
 		}
 		return
 	}
 }
 
-func lookupHttpRouteIndex(http, gw cache.SharedIndexInformer, gwclasses []string) func([]string) []netip.Addr {
-	return func(indexKeys []string) (result []netip.Addr) {
+func lookupHttpRouteIndex(http, gw cache.SharedIndexInformer, gwclasses []string) func([]string) map[string][]string {
+	return func(indexKeys []string) (result map[string][]string) {
 		var objs []interface{}
 		for _, key := range indexKeys {
 			obj, _ := http.GetIndexer().ByIndex(httpRouteHostnameIndex, strings.ToLower(key))
@@ -559,14 +581,17 @@ func lookupHttpRouteIndex(http, gw cache.SharedIndexInformer, gwclasses []string
 
 		for _, obj := range objs {
 			httpRoute, _ := obj.(*gatewayapi_v1.HTTPRoute)
-			result = append(result, lookupGateways(gw, httpRoute.Spec.ParentRefs, httpRoute.Namespace, gwclasses)...)
+
+			var fetchedResults map[string][]string
+			fetchedResults = lookupGateways(gw, httpRoute.Spec.ParentRefs, httpRoute.Namespace, gwclasses)
+			result = appenddnsResults(result, fetchedResults)
 		}
 		return
 	}
 }
 
-func lookupTLSRouteIndex(tls, gw cache.SharedIndexInformer, gwclasses []string) func([]string) []netip.Addr {
-	return func(indexKeys []string) (result []netip.Addr) {
+func lookupTLSRouteIndex(tls, gw cache.SharedIndexInformer, gwclasses []string) func([]string) map[string][]string {
+	return func(indexKeys []string) (result map[string][]string) {
 		var objs []interface{}
 		for _, key := range indexKeys {
 			obj, _ := tls.GetIndexer().ByIndex(tlsRouteHostnameIndex, strings.ToLower(key))
@@ -576,14 +601,17 @@ func lookupTLSRouteIndex(tls, gw cache.SharedIndexInformer, gwclasses []string) 
 
 		for _, obj := range objs {
 			tlsRoute, _ := obj.(*gatewayapi_v1alpha2.TLSRoute)
-			result = append(result, lookupGateways(gw, tlsRoute.Spec.ParentRefs, tlsRoute.Namespace, gwclasses)...)
+
+			var fetchedResults map[string][]string
+			fetchedResults = lookupGateways(gw, tlsRoute.Spec.ParentRefs, tlsRoute.Namespace, gwclasses)
+			result = appenddnsResults(result, fetchedResults)
 		}
 		return
 	}
 }
 
-func lookupGRPCRouteIndex(grpc, gw cache.SharedIndexInformer, gwclasses []string) func([]string) []netip.Addr {
-	return func(indexKeys []string) (result []netip.Addr) {
+func lookupGRPCRouteIndex(grpc, gw cache.SharedIndexInformer, gwclasses []string) func([]string) map[string][]string {
+	return func(indexKeys []string) (result map[string][]string) {
 		var objs []interface{}
 		for _, key := range indexKeys {
 			obj, _ := grpc.GetIndexer().ByIndex(grpcRouteHostnameIndex, strings.ToLower(key))
@@ -593,13 +621,16 @@ func lookupGRPCRouteIndex(grpc, gw cache.SharedIndexInformer, gwclasses []string
 
 		for _, obj := range objs {
 			grpcRoute, _ := obj.(*gatewayapi_v1.GRPCRoute)
-			result = append(result, lookupGateways(gw, grpcRoute.Spec.ParentRefs, grpcRoute.Namespace, gwclasses)...)
+
+			var fetchedResults map[string][]string
+			fetchedResults = lookupGateways(gw, grpcRoute.Spec.ParentRefs, grpcRoute.Namespace, gwclasses)
+			result = appenddnsResults(result, fetchedResults)
 		}
 		return
 	}
 }
 
-func lookupGateways(gw cache.SharedIndexInformer, refs []gatewayapi_v1.ParentReference, ns string, gwclasses []string) (result []netip.Addr) {
+func lookupGateways(gw cache.SharedIndexInformer, refs []gatewayapi_v1.ParentReference, ns string, gwclasses []string) (result map[string][]string) {
 	for _, gwRef := range refs {
 
 		if gwRef.Namespace != nil {
@@ -618,14 +649,16 @@ func lookupGateways(gw cache.SharedIndexInformer, refs []gatewayapi_v1.ParentRef
 				continue
 			}
 
-			result = append(result, fetchGatewayIPs(gw)...)
+			var fetchedResults map[string][]string
+			fetchedResults = fetchGatewayIPs(gw)
+			result = appenddnsResults(result, fetchedResults)
 		}
 	}
 	return
 }
 
-func lookupIngressIndex(ctrl cache.SharedIndexInformer, ingclasses []string) func([]string) []netip.Addr {
-	return func(indexKeys []string) (result []netip.Addr) {
+func lookupIngressIndex(ctrl cache.SharedIndexInformer, ingclasses []string) func([]string) map[string][]string {
+	return func(indexKeys []string) (result map[string][]string) {
 		var objs []interface{}
 		for _, key := range indexKeys {
 			obj, _ := ctrl.GetIndexer().ByIndex(ingressHostnameIndex, strings.ToLower(key))
@@ -640,15 +673,21 @@ func lookupIngressIndex(ctrl cache.SharedIndexInformer, ingclasses []string) fun
 				continue
 			}
 
-			result = append(result, fetchIngressLoadBalancerIPs(ingress.Status.LoadBalancer.Ingress)...)
+			var fetchedResults map[string][]string
+			fetchedResults = fetchIngressLoadBalancerIPs(ingress.Status.LoadBalancer.Ingress)
+			result = appenddnsResults(result, fetchedResults)
 		}
 
 		return
 	}
 }
 
-func lookupDNSEndpoint(ctrl cache.SharedIndexInformer) func([]string) (results []netip.Addr) {
-	return func(indexKeys []string) (result []netip.Addr) {
+func lookupDNSEndpoint(ctrl cache.SharedIndexInformer) func([]string) (results map[string][]string) {
+	return func(indexKeys []string) (result map[string][]string) {
+		if result == nil {
+			result = make(map[string][]string, 0)
+		}
+
 		var objs []interface{}
 		for _, key := range indexKeys {
 			obj, _ := ctrl.GetIndexer().ByIndex(externalDNSHostnameIndex, strings.ToLower(key))
@@ -660,12 +699,31 @@ func lookupDNSEndpoint(ctrl cache.SharedIndexInformer) func([]string) (results [
 
 			for _, endpoint := range dnsEndpoint.Spec.Endpoints {
 				for _, target := range endpoint.Targets {
-					if endpoint.RecordType == "A" || endpoint.RecordType == "AAAA" {
+					if endpoint.RecordType == "A" {
 						addr, err := netip.ParseAddr(target)
 						if err != nil {
 							continue
 						}
-						result = append(result, addr)
+						if result["A"] == nil {
+							result["A"] = make([]string, 0)
+						}
+						result["A"] = append(result["A"], addr.String())
+					}
+					if endpoint.RecordType == "AAAA" {
+						addr, err := netip.ParseAddr(target)
+						if err != nil {
+							continue
+						}
+						if result["AAAA"] == nil {
+							result["AAAA"] = make([]string, 0)
+						}
+						result["AAAA"] = append(result["AAAA"], addr.String())
+					}
+					if endpoint.RecordType == "TXT" {
+						if result["TXT"] == nil {
+							result["TXT"] = make([]string, 0)
+						}
+						result["TXT"] = append(result["TXT"], target)
 					}
 				}
 			}
@@ -674,14 +732,29 @@ func lookupDNSEndpoint(ctrl cache.SharedIndexInformer) func([]string) (results [
 	}
 }
 
-func fetchGatewayIPs(gw *gatewayapi_v1.Gateway) (results []netip.Addr) {
+func fetchGatewayIPs(gw *gatewayapi_v1.Gateway) (results map[string][]string) {
+	if results == nil {
+		results = make(map[string][]string, 0)
+	}
+
 	for _, addr := range gw.Status.Addresses {
 		if *addr.Type == gatewayapi_v1.IPAddressType {
 			addr, err := netip.ParseAddr(addr.Value)
 			if err != nil {
 				continue
 			}
-			results = append(results, addr)
+			if addr.Is4() {
+				if results["A"] == nil {
+					results["A"] = make([]string, 0)
+				}
+				results["A"] = append(results["A"], addr.String())
+			}
+			if addr.Is6() {
+				if results["AAAA"] == nil {
+					results["AAAA"] = make([]string, 0)
+				}
+				results["AAAA"] = append(results["AAAA"], addr.String())
+			}
 			continue
 		}
 
@@ -695,14 +768,29 @@ func fetchGatewayIPs(gw *gatewayapi_v1.Gateway) (results []netip.Addr) {
 				if err != nil {
 					continue
 				}
-				results = append(results, addr)
+				if addr.Is4() {
+					if results["A"] == nil {
+						results["A"] = make([]string, 0)
+					}
+					results["A"] = append(results["A"], addr.String())
+				}
+				if addr.Is6() {
+					if results["AAAA"] == nil {
+						results["AAAA"] = make([]string, 0)
+					}
+					results["AAAA"] = append(results["AAAA"], addr.String())
+				}
 			}
 		}
 	}
 	return
 }
 
-func fetchServiceLoadBalancerIPs(ingresses []core.LoadBalancerIngress) (results []netip.Addr) {
+func fetchServiceLoadBalancerIPs(ingresses []core.LoadBalancerIngress) (results map[string][]string) {
+	if results == nil {
+		results = make(map[string][]string, 0)
+	}
+
 	for _, address := range ingresses {
 		if address.Hostname != "" {
 			log.Debugf("Looking up hostname %s", address.Hostname)
@@ -715,20 +803,46 @@ func fetchServiceLoadBalancerIPs(ingresses []core.LoadBalancerIngress) (results 
 				if err != nil {
 					continue
 				}
-				results = append(results, addr)
+				if addr.Is4() {
+					if results["A"] == nil {
+						results["A"] = make([]string, 0)
+					}
+					results["A"] = append(results["A"], addr.String())
+				}
+				if addr.Is6() {
+					if results["AAAA"] == nil {
+						results["AAAA"] = make([]string, 0)
+					}
+					results["AAAA"] = append(results["AAAA"], addr.String())
+				}
 			}
 		} else if address.IP != "" {
 			addr, err := netip.ParseAddr(address.IP)
 			if err != nil {
 				continue
 			}
-			results = append(results, addr)
+			if addr.Is4() {
+				if results["A"] == nil {
+					results["A"] = make([]string, 0)
+				}
+				results["A"] = append(results["A"], addr.String())
+			}
+			if addr.Is6() {
+				if results["AAAA"] == nil {
+					results["AAAA"] = make([]string, 0)
+				}
+				results["AAAA"] = append(results["AAAA"], addr.String())
+			}
 		}
 	}
 	return
 }
 
-func fetchIngressLoadBalancerIPs(ingresses []networking.IngressLoadBalancerIngress) (results []netip.Addr) {
+func fetchIngressLoadBalancerIPs(ingresses []networking.IngressLoadBalancerIngress) (results map[string][]string) {
+	if results == nil {
+		results = make(map[string][]string, 0)
+	}
+
 	for _, address := range ingresses {
 		if address.Hostname != "" {
 			log.Debugf("Looking up hostname %s", address.Hostname)
@@ -741,14 +855,36 @@ func fetchIngressLoadBalancerIPs(ingresses []networking.IngressLoadBalancerIngre
 				if err != nil {
 					continue
 				}
-				results = append(results, addr)
+				if addr.Is4() {
+					if results["A"] == nil {
+						results["A"] = make([]string, 0)
+					}
+					results["A"] = append(results["A"], addr.String())
+				}
+				if addr.Is6() {
+					if results["AAAA"] == nil {
+						results["AAAA"] = make([]string, 0)
+					}
+					results["AAAA"] = append(results["AAAA"], addr.String())
+				}
 			}
 		} else if address.IP != "" {
 			addr, err := netip.ParseAddr(address.IP)
 			if err != nil {
 				continue
 			}
-			results = append(results, addr)
+			if addr.Is4() {
+				if results["A"] == nil {
+					results["A"] = make([]string, 0)
+				}
+				results["A"] = append(results["A"], addr.String())
+			}
+			if addr.Is6() {
+				if results["AAAA"] == nil {
+					results["AAAA"] = make([]string, 0)
+				}
+				results["AAAA"] = append(results["AAAA"], addr.String())
+			}
 		}
 	}
 	return
@@ -764,4 +900,27 @@ var dns1123SubdomainRegexp = regexp.MustCompile("^" + dns1123SubdomainFmt + "$")
 
 func isdns1123Hostname(value string) bool {
 	return dns1123SubdomainRegexp.MatchString(value)
+}
+
+func appenddnsResults(result map[string][]string, fetchedResults map[string][]string) map[string][]string {
+	if result == nil {
+		result = make(map[string][]string, 0)
+	}
+
+	if result["A"] == nil {
+		result["A"] = make([]string, 0)
+	}
+	result["A"] = append(result["A"], fetchedResults["A"]...)
+
+	if result["AAAA"] == nil {
+		result["AAAA"] = make([]string, 0)
+	}
+	result["AAAA"] = append(result["AAAA"], fetchedResults["AAAA"]...)
+
+	if result["TXT"] == nil {
+		result["TXT"] = make([]string, 0)
+	}
+	result["TXT"] = append(result["TXT"], fetchedResults["TXT"]...)
+
+	return result
 }

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -529,6 +529,11 @@ var testDNSEndpoints = map[string]*externaldnsv1.DNSEndpoint{
 					RecordType: "AAAA",
 					Targets:    []string{"2001:db8::1"},
 				},
+				{
+					DNSName:    "dual.example.com",
+					RecordType: "TXT",
+					Targets:    []string{"challenge"},
+				},
 			},
 		},
 	},

--- a/test/dnsendpoint.yaml
+++ b/test/dnsendpoint.yaml
@@ -24,3 +24,7 @@ spec:
       recordType: AAAA
       targets:
         - 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+    - dnsName: "test4.example.dev"
+      recordType: TXT
+      targets:
+        - challenge

--- a/test/gateway-api/resources.yml
+++ b/test/gateway-api/resources.yml
@@ -126,7 +126,7 @@ spec:
         - name: backend
           port: 443
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: GRPCRoute
 metadata:
   name: myservicegrpc

--- a/test/get-dnsendpoint-crds-for-tilt.sh
+++ b/test/get-dnsendpoint-crds-for-tilt.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+curl -sL https://kubernetes-sigs.github.io/external-dns/v0.16.1/docs/sources/crd/crd-manifest.yaml -o /tmp/dnsendpoint.yaml
+
+echo "$(</tmp/dnsendpoint.yaml)"

--- a/test/get-gateway-api-crds-for-tilt.sh
+++ b/test/get-gateway-api-crds-for-tilt.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+curl -sL https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/experimental-install.yaml -o /tmp/experimental-install.yaml
+
+echo "$(</tmp/experimental-install.yaml)"


### PR DESCRIPTION
I rewrote the map of records to make it more flexible for more types.

Quite weirdly the TXT type does not work yet and I don't know why.

```
panic: interface conversion: dns.RR is nil, not *dns.TXT

goroutine 1 [running]:
github.com/coredns/coredns/plugin/test.TXT(...)
        REDACTED/go/pkg/mod/github.com/coredns/coredns@v1.12.2/plugin/test/helpers.go:87
github.com/k8s-gateway/k8s_gateway.init()
        REDACTED/k8s_gateway/gateway_test.go:262 +0x26e5
FAIL    github.com/k8s-gateway/k8s_gateway      0.071s
=== RUN   TestInit
--- PASS: TestInit (0.00s)
PASS
ok      github.com/k8s-gateway/k8s_gateway/cmd  1.083s
FAIL
```

It seems that for TXT records specifically coredns disables the plugin. But why ?

I will dig a bit more but if you have an idea ?