### PR TITLE
feat: add posibility to exclude some objects from resolving

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,35 @@ k8s_gateway example.com {
 }
 ```
 
+## Excluding Specific Resources
+
+In some cases, you may want to exclude specific Kubernetes resources from being processed by the `k8s_gateway` plugin. This can be useful when you have resources that should not be exposed via DNS or when you want to temporarily disable DNS resolution for certain objects.
+
+### Using the Ignore Label
+
+You can exclude any supported resource type by adding the `k8s-gateway.dns/ignore` label with the value `"true"` to the resource's metadata:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: my-ingress
+  labels:
+    k8s-gateway.dns/ignore: "true"  # This ingress will be excluded from DNS resolution
+spec:
+  # ... rest of spec
+```
+
+This label works for all supported resource types:
+- **Ingress** resources
+- **Service** resources (of type LoadBalancer)
+- **HTTPRoute** resources
+- **TLSRoute** resources  
+- **GRPCRoute** resources
+- **DNSEndpoint** resources
+
+When a resource is excluded using this label, the plugin will not return it's address.
+
 ## Dual Nameserver Deployment
 
 Most of the time, deploying a single `k8s_gateway` instance is enough to satisfy most popular DNS resolvers. However, some of the stricter resolvers expect a zone to be available on at least two servers (RFC1034, section 4.1). In order to satisfy this requirement, a pair of `k8s_gateway` instances need to be deployed, each with its own unique loadBalancer IP. This way the zone NS record will point to a pair of glue records, hard-coded to these IPs.

--- a/test/gateway-api/resources.yml
+++ b/test/gateway-api/resources.yml
@@ -143,3 +143,24 @@ spec:
       backendRefs:
         - name: backend
           port: 443
+
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ignored-httproute
+  namespace: default
+  labels:
+    k8s-gateway.dns/ignore: "true"
+spec:
+  parentRefs:
+    - name: gateway-one
+  hostnames: ["ignored-httproute.ignored.gw.foo.org"]
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: backend
+          port: 80

--- a/test/single-stack/ingress-services.yml
+++ b/test/single-stack/ingress-services.yml
@@ -33,3 +33,43 @@ spec:
     app: backend
   sessionAffinity: None
   type: LoadBalancer
+
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ignored-ingress
+  namespace: default
+  labels:
+    k8s-gateway.dns/ignore: "true"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: ignored.foo.org
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ignored-service
+  namespace: default
+  labels:
+    k8s-gateway.dns/ignore: "true"
+spec:
+  ports:
+    - name: 80-80
+      port: 80
+      protocol: TCP
+      targetPort: 80
+  selector:
+    app: backend
+  sessionAffinity: None
+  type: LoadBalancer


### PR DESCRIPTION
I have a specific case where we are using this plugin to take advantage of our CNI functionalities to restrict traffic within the cluster. We need a filtering function that allows us to exclude certain objects from resolution by the plugin, so their hostname resolution is passed to the fallthrough/forward DNS servers.

This PR introduces such functionality.