### PR TITLE
Add wildcard and multi-host support for service annotations

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -573,7 +573,7 @@ func checkServiceAnnotation(annotation string, service *core.Service) (string, b
 func checkDomainValid(domain string) bool {
 	if _, ok := dns.IsDomainName(domain); ok {
 		// checking RFC 1123 conformance (same as metadata labels)
-		if valid := isdns1123Hostname(domain); valid {
+		if valid := isdns1123Hostname(strings.TrimPrefix(domain, "*.")); valid {
 			return true
 		}
 		log.Infof("RFC 1123 conformance failed for FQDN: %s", domain)

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -517,14 +517,8 @@ func serviceHostnameIndexFunc(obj interface{}) ([]string, error) {
 		return []string{}, nil
 	}
 
-	hostname := service.Name + "." + service.Namespace
-	hostnames := []string{}
-	if annotation, exists := checkServiceAnnotation(hostnameAnnotationKey, service); exists {
-		if checkDomainValid(annotation) {
-			hostnames = []string{annotation}
-			log.Debugf("Adding index %s for service %s", annotation, service.Name)
-		}
-	} else if annotation, exists := checkServiceAnnotation(externalDnsHostnameAnnotationKey, service); exists {
+	var hostnames []string
+	if annotation, exists := checkServiceAnnotations(service, hostnameAnnotationKey, externalDnsHostnameAnnotationKey); exists {
 		for _, hostname := range splitHostnameAnnotation(annotation) {
 			if checkDomainValid(hostname) {
 				hostnames = append(hostnames, hostname)
@@ -532,7 +526,7 @@ func serviceHostnameIndexFunc(obj interface{}) ([]string, error) {
 			}
 		}
 	} else {
-		hostnames = []string{hostname}
+		hostnames = []string{service.Name + "." + service.Namespace}
 	}
 
 	return hostnames, nil
@@ -562,9 +556,11 @@ func dnsEndpointTargetIndexFunc(obj interface{}) ([]string, error) {
 	return hostnames, nil
 }
 
-func checkServiceAnnotation(annotation string, service *core.Service) (string, bool) {
-	if annotationValue, exists := service.Annotations[annotation]; exists {
-		return strings.ToLower(annotationValue), true
+func checkServiceAnnotations(service *core.Service, annotations ...string) (string, bool) {
+	for _, annotation := range annotations {
+		if annotationValue, exists := service.Annotations[annotation]; exists {
+			return strings.ToLower(annotationValue), true
+		}
 	}
 
 	return "", false

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -453,9 +453,28 @@ var testServices = map[string]*core.Service{
 			},
 		},
 	},
-	"annotation-external-dns": {
+	"annotation-list1, annotation-list2": {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "svc5",
+			Namespace: "ns1",
+			Annotations: map[string]string{
+				"coredns.io/hostname": "annotation-list1, annotation-list2",
+			},
+		},
+		Spec: core.ServiceSpec{
+			Type: core.ServiceTypeLoadBalancer,
+		},
+		Status: core.ServiceStatus{
+			LoadBalancer: core.LoadBalancerStatus{
+				Ingress: []core.LoadBalancerIngress{
+					{IP: "192.0.0.3"},
+				},
+			},
+		},
+	},
+	"annotation-external-dns": {
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc6",
 			Namespace: "ns1",
 			Annotations: map[string]string{
 				"external-dns.alpha.kubernetes.io/hostname": "annotation-external-dns",
@@ -474,7 +493,7 @@ var testServices = map[string]*core.Service{
 	},
 	"annotation-external-dns-list1,annotation-external-dns-list2": {
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "svc6",
+			Name:      "svc7",
 			Namespace: "ns1",
 			Annotations: map[string]string{
 				"external-dns.alpha.kubernetes.io/hostname": "annotation-external-dns-list1,annotation-external-dns-list2",

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -174,6 +174,13 @@ func TestController(t *testing.T) {
 		}
 	}
 
+	for _, testObj := range testInvalidAnnotationServices {
+		found, _ := serviceHostnameIndexFunc(testObj)
+		if len(found) != 0 {
+			t.Errorf("Unexpected non-empty service hostnames %v for invalid annotation: %v", found, testObj.Annotations)
+		}
+	}
+
 	for index, testObj := range testHTTPRoutes {
 		found, _ := httpRouteHostnameIndexFunc(testObj)
 		if checkIgnoreLabel(testObj.Labels) {
@@ -654,6 +661,66 @@ var testBadServices = map[string]*core.Service{
 		},
 		Spec: core.ServiceSpec{
 			Type: core.ServiceTypeClusterIP,
+		},
+		Status: core.ServiceStatus{
+			LoadBalancer: core.LoadBalancerStatus{
+				Ingress: []core.LoadBalancerIngress{
+					{IP: "192.0.0.1"},
+				},
+			},
+		},
+	},
+}
+
+var testInvalidAnnotationServices = []*core.Service{
+	{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc1",
+			Namespace: "ns3",
+			Annotations: map[string]string{
+				"coredns.io/hostname": "*my.host",
+			},
+		},
+		Spec: core.ServiceSpec{
+			Type: core.ServiceTypeLoadBalancer,
+		},
+		Status: core.ServiceStatus{
+			LoadBalancer: core.LoadBalancerStatus{
+				Ingress: []core.LoadBalancerIngress{
+					{IP: "192.0.0.1"},
+				},
+			},
+		},
+	},
+	{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc2",
+			Namespace: "ns3",
+			Annotations: map[string]string{
+				"coredns.io/hostname": "**my.host",
+			},
+		},
+		Spec: core.ServiceSpec{
+			Type: core.ServiceTypeLoadBalancer,
+		},
+		Status: core.ServiceStatus{
+			LoadBalancer: core.LoadBalancerStatus{
+				Ingress: []core.LoadBalancerIngress{
+					{IP: "192.0.0.1"},
+				},
+			},
+		},
+	},
+	{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc3",
+			Namespace: "ns3",
+			Annotations: map[string]string{
+				"external-dns.alpha.kubernetes.io/hostname": "my.*.host",
+			},
+		},
+		Spec: core.ServiceSpec{
+			Type: core.ServiceTypeLoadBalancer,
 		},
 		Status: core.ServiceStatus{
 			LoadBalancer: core.LoadBalancerStatus{

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -434,9 +434,28 @@ var testServices = map[string]*core.Service{
 			},
 		},
 	},
+	"*.annotation-wildcard": {
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc4",
+			Namespace: "ns1",
+			Annotations: map[string]string{
+				"coredns.io/hostname": "*.annotation-wildcard",
+			},
+		},
+		Spec: core.ServiceSpec{
+			Type: core.ServiceTypeLoadBalancer,
+		},
+		Status: core.ServiceStatus{
+			LoadBalancer: core.LoadBalancerStatus{
+				Ingress: []core.LoadBalancerIngress{
+					{IP: "192.0.0.3"},
+				},
+			},
+		},
+	},
 	"annotation-external-dns": {
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "svc3",
+			Name:      "svc5",
 			Namespace: "ns1",
 			Annotations: map[string]string{
 				"external-dns.alpha.kubernetes.io/hostname": "annotation-external-dns",
@@ -455,7 +474,7 @@ var testServices = map[string]*core.Service{
 	},
 	"annotation-external-dns-list1,annotation-external-dns-list2": {
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "svc3",
+			Name:      "svc6",
 			Namespace: "ns1",
 			Annotations: map[string]string{
 				"external-dns.alpha.kubernetes.io/hostname": "annotation-external-dns-list1,annotation-external-dns-list2",


### PR DESCRIPTION
This PR fixes #144 by fixing the following:
- Wildcards are now allowed in service annotations, using `coredns.io/hostname` or `external-dns.alpha.kubernetes.io/hostname`. Only leading wildcards are supported, i.e. `"*.my.host"`. This is in alignment with the wildcard support added in #57 for ingress and gateway resources.
- The `coredns.io/hostname` now allows multiple comma-separated hostnames. Previously only `external-dns.alpha.kubernetes.io/hostname` allowed multiple hostnames to be used.

The PR includes 2 new test cases for these features.

The implementation is a little different than #144 to hopefully make the final implementation a little easier to understand. As far as I could tell [RFC 1123](https://datatracker.ietf.org/doc/html/rfc1123) does not mention a wildcard syntax, so it seemed appropriate to leave the `isdns1123Hostname` function untouched.