### PR TITLE
Add project URL to Helm chart metadata

### DIFF
--- a/charts/k8s-gateway/Chart.yaml
+++ b/charts/k8s-gateway/Chart.yaml
@@ -2,12 +2,15 @@ apiVersion: v2
 name: k8s-gateway
 description: A Helm chart for the k8s_gateway CoreDNS plugin
 type: application
-version: 3.6.0
+version: 3.6.1
 appVersion: 1.7.0
+home: https://github.com/k8s-gateway/k8s_gateway
+sources:
+  - https://github.com/k8s-gateway/k8s_gateway
 maintainers:
   - url: https://github.com/samip5
     name: samip5
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: appVersion from 1.6.4 to 1.7.0
+    - kind: added
+      description: add project URL to chart metadata


### PR DESCRIPTION
I _think_ (hope) this will help Renovate find the chart's changelogs. This is untested, but worst case it adds metadata that will be useful for other purposes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped Helm chart version to 3.6.1
  * Enhanced chart metadata with direct repository links for improved discoverability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->