### PR TITLE
feat: add serviceLabelSelector for label-based Service filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ k8s_gateway [ZONES...]
     resources [RESOURCES...]
     ingressClasses [CLASSES...]
     gatewayClasses [CLASSES...]
+    serviceLabelSelector SELECTOR
     ttl TTL
     apex APEX
     secondary SECONDARY
@@ -69,6 +70,7 @@ k8s_gateway [ZONES...]
 * `resources` a subset of supported Kubernetes resources to watch. Available options are `[ Ingress | Service | HTTPRoute | TLSRoute | GRPCRoute | DNSEndpoint ]`. If no resources are specified only `Ingress` and `Service` will be monitored
 * `ingressClasses` to filter `Ingress` resources by `ingressClassName` values. Watches all by default.
 * `gatewayClasses` to filter `Gateway` resources by `gatewayClassName` values. Watches all by default.
+* `serviceLabelSelector` to filter `Service` resources by labels using a [Kubernetes label selector](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors) string. Watches all by default.
 * `ttl` can be used to override the default TTL value of 60 seconds.
 * `apex` can be used to override the default apex record value of `{ReleaseName}-k8s-gateway.{Namespace}`
 * `secondary` can be used to specify the optional apex record value of a peer nameserver running in the cluster (see `Dual Nameserver Deployment` section below).

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ k8s_gateway [ZONES...]
     resources [RESOURCES...]
     ingressClasses [CLASSES...]
     gatewayClasses [CLASSES...]
-    serviceLabelSelector SELECTOR
+    serviceLabelSelectors SELECTOR [SELECTOR...]
     ttl TTL
     apex APEX
     secondary SECONDARY
@@ -70,7 +70,7 @@ k8s_gateway [ZONES...]
 * `resources` a subset of supported Kubernetes resources to watch. Available options are `[ Ingress | Service | HTTPRoute | TLSRoute | GRPCRoute | DNSEndpoint ]`. If no resources are specified only `Ingress` and `Service` will be monitored
 * `ingressClasses` to filter `Ingress` resources by `ingressClassName` values. Watches all by default.
 * `gatewayClasses` to filter `Gateway` resources by `gatewayClassName` values. Watches all by default.
-* `serviceLabelSelector` to filter `Service` resources by labels using a [Kubernetes label selector](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors) string. Watches all by default.
+* `serviceLabelSelectors` to filter `Service` resources by labels using one or more [Kubernetes label selector](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors) strings. Each selector creates a separate watch; results are merged. Watches all by default.
 * `ttl` can be used to override the default TTL value of 60 seconds.
 * `apex` can be used to override the default apex record value of `{ReleaseName}-k8s-gateway.{Namespace}`
 * `secondary` can be used to specify the optional apex record value of a peer nameserver running in the cluster (see `Dual Nameserver Deployment` section below).

--- a/charts/k8s-gateway/Chart.yaml
+++ b/charts/k8s-gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-gateway
 description: A Helm chart for the k8s_gateway CoreDNS plugin
 type: application
-version: 3.6.1
+version: 3.7.0
 appVersion: 1.7.0
 home: https://github.com/k8s-gateway/k8s_gateway
 sources:
@@ -13,4 +13,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: add project URL to chart metadata
+      description: add serviceLabelSelector filter for label-based Service filtering

--- a/charts/k8s-gateway/Chart.yaml
+++ b/charts/k8s-gateway/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: add serviceLabelSelector filter for label-based Service filtering
+      description: support multiple serviceLabelSelectors for OR-of-ANDs filtering

--- a/charts/k8s-gateway/README.md
+++ b/charts/k8s-gateway/README.md
@@ -15,6 +15,7 @@ The following table lists the configurable parameters of the k8s_gateway chart a
 | `watchedResources`               | Resources to watch, e.g. `watchedResources: ["Ingress"]`                                  | `["Ingress", "Service"]`|
 | `filters.ingressClasses`         | Filter Ingress resources by their IngressClassName property                               | `[]`                  |
 | `filters.gatewayClasses`         | Filter Gateway resources by their GatewayClassName property                               | `[]`                  |
+| `filters.serviceLabelSelectors`  | Filter Service resources by label selectors. Each selector creates a separate watch; results are merged | `[]`  |
 | `fallthrough.enabled`            | Enable fallthrough support                                                                | `false`               |
 | `fallthrough.zones`              | List of zones to enable fallthrough on                                                    | `[]`                  |
 | `ttl`                            | TTL for non-apex responses (in seconds)                                                   | `300`                 |

--- a/charts/k8s-gateway/templates/configmap.yaml
+++ b/charts/k8s-gateway/templates/configmap.yaml
@@ -36,8 +36,8 @@ data:
           {{- if .Values.filters.gatewayClasses }}
           gatewayClasses {{ join " " .Values.filters.gatewayClasses }}
           {{- end }}
-          {{- if .Values.filters.serviceLabelSelector }}
-          serviceLabelSelector {{ .Values.filters.serviceLabelSelector | quote }}
+          {{- if .Values.filters.serviceLabelSelectors }}
+          serviceLabelSelectors{{ range .Values.filters.serviceLabelSelectors }} {{ . | quote }}{{ end }}
           {{- end }}
           {{- if .Values.fallthrough.enabled }}
           fallthrough {{- range .Values.fallthrough.zones }} {{ . }} {{- end }}

--- a/charts/k8s-gateway/templates/configmap.yaml
+++ b/charts/k8s-gateway/templates/configmap.yaml
@@ -36,6 +36,9 @@ data:
           {{- if .Values.filters.gatewayClasses }}
           gatewayClasses {{ join " " .Values.filters.gatewayClasses }}
           {{- end }}
+          {{- if .Values.filters.serviceLabelSelector }}
+          serviceLabelSelector {{ .Values.filters.serviceLabelSelector | quote }}
+          {{- end }}
           {{- if .Values.fallthrough.enabled }}
           fallthrough {{- range .Values.fallthrough.zones }} {{ . }} {{- end }}
           {{- end }}

--- a/charts/k8s-gateway/tests/configmap_test.yaml
+++ b/charts/k8s-gateway/tests/configmap_test.yaml
@@ -206,6 +206,98 @@ tests:
                 reload
                 loadbalance
               }
+  - it: Should render ConfigMap with single serviceLabelSelector
+    set:
+      domain: "example.com"
+      watchedResources:
+        - Service
+      ttl: 300
+      filters:
+        serviceLabelSelectors:
+          - "env=prod"
+    template: templates/configmap.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - matchRegex:
+          path: data.Corefile
+          pattern: 'serviceLabelSelectors "env=prod"'
+      - equal:
+          path: data.Corefile
+          value: |-
+            .:1053 {
+                k8s_gateway example.com {
+                  apex RELEASE-NAME-k8s-gateway.NAMESPACE
+                  ttl 300
+                  resources Service
+                  serviceLabelSelectors "env=prod"
+                }
+                log
+                errors
+                health {
+                  lameduck 5s
+                }
+                ready
+                prometheus 0.0.0.0:9153
+                forward . /etc/resolv.conf
+                loop
+                reload
+                loadbalance
+              }
+  - it: Should render ConfigMap with multiple serviceLabelSelectors
+    set:
+      domain: "example.com"
+      watchedResources:
+        - Service
+      ttl: 300
+      filters:
+        serviceLabelSelectors:
+          - "zone=kitchen,tier=frontend"
+          - "zone=bedroom,tier=backend"
+    template: templates/configmap.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - matchRegex:
+          path: data.Corefile
+          pattern: 'serviceLabelSelectors "zone=kitchen,tier=frontend" "zone=bedroom,tier=backend"'
+      - equal:
+          path: data.Corefile
+          value: |-
+            .:1053 {
+                k8s_gateway example.com {
+                  apex RELEASE-NAME-k8s-gateway.NAMESPACE
+                  ttl 300
+                  resources Service
+                  serviceLabelSelectors "zone=kitchen,tier=frontend" "zone=bedroom,tier=backend"
+                }
+                log
+                errors
+                health {
+                  lameduck 5s
+                }
+                ready
+                prometheus 0.0.0.0:9153
+                forward . /etc/resolv.conf
+                loop
+                reload
+                loadbalance
+              }
+  - it: Should not render serviceLabelSelectors when empty
+    set:
+      domain: "example.com"
+      watchedResources:
+        - Service
+      ttl: 300
+      filters:
+        serviceLabelSelectors: []
+    template: templates/configmap.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - notMatchRegex:
+          path: data.Corefile
+          pattern: "serviceLabelSelectors"
   - it: Should render ConfigMap without scheme prefix when empty
     set:
       domain: "example.com"

--- a/charts/k8s-gateway/tests/configmap_test.yaml
+++ b/charts/k8s-gateway/tests/configmap_test.yaml
@@ -252,15 +252,15 @@ tests:
       ttl: 300
       filters:
         serviceLabelSelectors:
-          - "zone=kitchen,tier=frontend"
-          - "zone=bedroom,tier=backend"
+          - "app=service1,tier=frontend"
+          - "app=service2,tier=backend"
     template: templates/configmap.yaml
     asserts:
       - hasDocuments:
           count: 1
       - matchRegex:
           path: data.Corefile
-          pattern: 'serviceLabelSelectors "zone=kitchen,tier=frontend" "zone=bedroom,tier=backend"'
+          pattern: 'serviceLabelSelectors "app=service1,tier=frontend" "app=service2,tier=backend"'
       - equal:
           path: data.Corefile
           value: |-
@@ -269,7 +269,7 @@ tests:
                   apex RELEASE-NAME-k8s-gateway.NAMESPACE
                   ttl 300
                   resources Service
-                  serviceLabelSelectors "zone=kitchen,tier=frontend" "zone=bedroom,tier=backend"
+                  serviceLabelSelectors "app=service1,tier=frontend" "app=service2,tier=backend"
                 }
                 log
                 errors

--- a/charts/k8s-gateway/values.yaml
+++ b/charts/k8s-gateway/values.yaml
@@ -39,6 +39,7 @@ watchedResources: ["Ingress", "Service"]
 filters:
   ingressClasses: []
   gatewayClasses: []
+  serviceLabelSelector: ""
 
 # Service name of a secondary DNS server (should be `serviceName.namespace`)
 secondary: ""

--- a/charts/k8s-gateway/values.yaml
+++ b/charts/k8s-gateway/values.yaml
@@ -39,7 +39,7 @@ watchedResources: ["Ingress", "Service"]
 filters:
   ingressClasses: []
   gatewayClasses: []
-  serviceLabelSelector: ""
+  serviceLabelSelectors: []
 
 # Service name of a secondary DNS server (should be `serviceName.namespace`)
 secondary: ""

--- a/gateway.go
+++ b/gateway.go
@@ -63,8 +63,9 @@ type Gateway struct {
 }
 
 type ResourceFilters struct {
-	ingressClasses []string
-	gatewayClasses []string
+	ingressClasses       []string
+	gatewayClasses       []string
+	serviceLabelSelector string
 }
 
 // Create a new Gateway instance

--- a/gateway.go
+++ b/gateway.go
@@ -63,9 +63,9 @@ type Gateway struct {
 }
 
 type ResourceFilters struct {
-	ingressClasses       []string
-	gatewayClasses       []string
-	serviceLabelSelector string
+	ingressClasses        []string
+	gatewayClasses        []string
+	serviceLabelSelectors []string
 }
 
 // Create a new Gateway instance
@@ -392,7 +392,7 @@ func (gw *Gateway) SelfAddress(state request.Request) (records []dns.RR) {
 			addrs1 = append(addrs1, results...)
 		}
 		results, raws = resource.lookup([]string{gw.secondNS})
-        _ = raws
+		_ = raws
 		if len(results) > 0 {
 			addrs2 = append(addrs2, results...)
 		}

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -134,8 +134,8 @@ func newKubeController(ctx context.Context, c *kubernetes.Clientset, gw *gateway
 				case "Service":
 					serviceController := cache.NewSharedIndexInformer(
 						&cache.ListWatch{
-							ListFunc:  serviceLister(ctx, ctrl.client, core.NamespaceAll),
-							WatchFunc: serviceWatcher(ctx, ctrl.client, core.NamespaceAll),
+							ListFunc:  serviceLister(ctx, ctrl.client, core.NamespaceAll, originalGateway.resourceFilters.serviceLabelSelector),
+							WatchFunc: serviceWatcher(ctx, ctrl.client, core.NamespaceAll, originalGateway.resourceFilters.serviceLabelSelector),
 						},
 						&core.Service{},
 						defaultResyncPeriod,
@@ -366,8 +366,9 @@ func ingressLister(ctx context.Context, c kubernetes.Interface, ns string) func(
 	}
 }
 
-func serviceLister(ctx context.Context, c kubernetes.Interface, ns string) func(metav1.ListOptions) (runtime.Object, error) {
+func serviceLister(ctx context.Context, c kubernetes.Interface, ns string, labelSelector string) func(metav1.ListOptions) (runtime.Object, error) {
 	return func(opts metav1.ListOptions) (runtime.Object, error) {
+		opts.LabelSelector = labelSelector
 		return c.CoreV1().Services(ns).List(ctx, opts)
 	}
 }
@@ -402,8 +403,9 @@ func ingressWatcher(ctx context.Context, c kubernetes.Interface, ns string) func
 	}
 }
 
-func serviceWatcher(ctx context.Context, c kubernetes.Interface, ns string) func(metav1.ListOptions) (watch.Interface, error) {
+func serviceWatcher(ctx context.Context, c kubernetes.Interface, ns string, labelSelector string) func(metav1.ListOptions) (watch.Interface, error) {
 	return func(opts metav1.ListOptions) (watch.Interface, error) {
+		opts.LabelSelector = labelSelector
 		return c.CoreV1().Services(ns).Watch(ctx, opts)
 	}
 }

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -132,17 +132,25 @@ func newKubeController(ctx context.Context, c *kubernetes.Clientset, gw *gateway
 					log.Infof("Ingress controller initialized")
 
 				case "Service":
-					serviceController := cache.NewSharedIndexInformer(
-						&cache.ListWatch{
-							ListFunc:  serviceLister(ctx, ctrl.client, core.NamespaceAll, originalGateway.resourceFilters.serviceLabelSelector),
-							WatchFunc: serviceWatcher(ctx, ctrl.client, core.NamespaceAll, originalGateway.resourceFilters.serviceLabelSelector),
-						},
-						&core.Service{},
-						defaultResyncPeriod,
-						cache.Indexers{serviceHostnameIndex: serviceHostnameIndexFunc},
-					)
-					resource.lookup = lookupServiceIndex(serviceController)
-					ctrl.controllers = append(ctrl.controllers, serviceController)
+					selectors := originalGateway.resourceFilters.serviceLabelSelectors
+					if len(selectors) == 0 {
+						selectors = []string{""}
+					}
+					var serviceControllers []cache.SharedIndexInformer
+					for _, sel := range selectors {
+						sc := cache.NewSharedIndexInformer(
+							&cache.ListWatch{
+								ListFunc:  serviceLister(ctx, ctrl.client, core.NamespaceAll, sel),
+								WatchFunc: serviceWatcher(ctx, ctrl.client, core.NamespaceAll, sel),
+							},
+							&core.Service{},
+							defaultResyncPeriod,
+							cache.Indexers{serviceHostnameIndex: serviceHostnameIndexFunc},
+						)
+						serviceControllers = append(serviceControllers, sc)
+						ctrl.controllers = append(ctrl.controllers, sc)
+					}
+					resource.lookup = lookupServiceIndex(serviceControllers)
 					log.Infof("Service controller initialized")
 				}
 			}
@@ -599,12 +607,26 @@ func checkDomainValid(domain string) bool {
 	return false
 }
 
-func lookupServiceIndex(ctrl cache.SharedIndexInformer) func([]string) (results []netip.Addr, raws []string) {
+func lookupServiceIndex(controllers []cache.SharedIndexInformer) func([]string) (results []netip.Addr, raws []string) {
 	return func(indexKeys []string) (result []netip.Addr, raw []string) {
+		seen := make(map[string]struct{})
 		var objs []interface{}
-		for _, key := range indexKeys {
-			obj, _ := ctrl.GetIndexer().ByIndex(serviceHostnameIndex, strings.ToLower(key))
-			objs = append(objs, obj...)
+		for _, ctrl := range controllers {
+			for _, key := range indexKeys {
+				obj, _ := ctrl.GetIndexer().ByIndex(serviceHostnameIndex, strings.ToLower(key))
+				for _, o := range obj {
+					svc, ok := o.(*core.Service)
+					if !ok {
+						continue
+					}
+					nsName := svc.Namespace + "/" + svc.Name
+					if _, dup := seen[nsName]; dup {
+						continue
+					}
+					seen[nsName] = struct{}{}
+					objs = append(objs, o)
+				}
+			}
 		}
 		log.Debugf("Found %d matching Service objects", len(objs))
 		for _, obj := range objs {

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -826,13 +826,13 @@ func TestServiceLabelSelector(t *testing.T) {
 }
 
 func TestMultiSelectorServiceLookup(t *testing.T) {
-	kitchenFrontend := &core.Service{
+	service1Frontend := &core.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "svc-kitchen-fe",
+			Name:      "service1-fe",
 			Namespace: "default",
-			Labels:    map[string]string{"zone": "kitchen", "tier": "frontend"},
+			Labels:    map[string]string{"app": "service1", "tier": "frontend"},
 			Annotations: map[string]string{
-				hostnameAnnotationKey: "kitchen-fe.example.com",
+				hostnameAnnotationKey: "service1-fe.example.com",
 			},
 		},
 		Spec: core.ServiceSpec{Type: core.ServiceTypeLoadBalancer},
@@ -843,13 +843,13 @@ func TestMultiSelectorServiceLookup(t *testing.T) {
 		},
 	}
 
-	bedroomBackend := &core.Service{
+	service2Backend := &core.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "svc-bedroom-be",
+			Name:      "service2-be",
 			Namespace: "default",
-			Labels:    map[string]string{"zone": "bedroom", "tier": "backend"},
+			Labels:    map[string]string{"app": "service2", "tier": "backend"},
 			Annotations: map[string]string{
-				hostnameAnnotationKey: "bedroom-be.example.com",
+				hostnameAnnotationKey: "service2-be.example.com",
 			},
 		},
 		Spec: core.ServiceSpec{Type: core.ServiceTypeLoadBalancer},
@@ -860,13 +860,13 @@ func TestMultiSelectorServiceLookup(t *testing.T) {
 		},
 	}
 
-	garageService := &core.Service{
+	service3Frontend := &core.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "svc-garage",
+			Name:      "service3-fe",
 			Namespace: "default",
-			Labels:    map[string]string{"zone": "garage", "tier": "frontend"},
+			Labels:    map[string]string{"app": "service3", "tier": "frontend"},
 			Annotations: map[string]string{
-				hostnameAnnotationKey: "garage.example.com",
+				hostnameAnnotationKey: "service3-fe.example.com",
 			},
 		},
 		Spec: core.ServiceSpec{Type: core.ServiceTypeLoadBalancer},
@@ -879,25 +879,25 @@ func TestMultiSelectorServiceLookup(t *testing.T) {
 
 	// Build two indexers with disjoint selectors, simulating what kubernetes.go
 	// does when multiple serviceLabelSelectors are configured.
-	// Selector 1: zone=kitchen,tier=frontend -> matches kitchenFrontend
-	// Selector 2: zone=bedroom,tier=backend  -> matches bedroomBackend
-	// garageService matches neither.
+	// Selector 1: app=service1,tier=frontend -> matches service1Frontend
+	// Selector 2: app=service2,tier=backend  -> matches service2Backend
+	// service3Frontend matches neither.
 
 	indexer1 := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
 		serviceHostnameIndex: serviceHostnameIndexFunc,
 	})
-	if err := indexer1.Add(kitchenFrontend); err != nil {
+	if err := indexer1.Add(service1Frontend); err != nil {
 		t.Fatalf("failed to add service to indexer1: %v", err)
 	}
 
 	indexer2 := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
 		serviceHostnameIndex: serviceHostnameIndexFunc,
 	})
-	if err := indexer2.Add(bedroomBackend); err != nil {
+	if err := indexer2.Add(service2Backend); err != nil {
 		t.Fatalf("failed to add service to indexer2: %v", err)
 	}
 
-	_ = garageService // not added to any indexer
+	_ = service3Frontend // not added to any indexer
 
 	controllers := []cache.SharedIndexInformer{
 		&fakeSharedIndexInformer{indexer: indexer1},
@@ -907,31 +907,27 @@ func TestMultiSelectorServiceLookup(t *testing.T) {
 	lookup := lookupServiceIndex(controllers)
 
 	t.Run("union of disjoint selectors returns both services", func(t *testing.T) {
-		// Query for kitchen-fe hostname
-		results1, _ := lookup([]string{"kitchen-fe.example.com"})
+		results1, _ := lookup([]string{"service1-fe.example.com"})
 		if len(results1) != 1 || results1[0].String() != "10.0.0.1" {
 			t.Errorf("expected [10.0.0.1], got %v", results1)
 		}
 
-		// Query for bedroom-be hostname
-		results2, _ := lookup([]string{"bedroom-be.example.com"})
+		results2, _ := lookup([]string{"service2-be.example.com"})
 		if len(results2) != 1 || results2[0].String() != "10.0.0.2" {
 			t.Errorf("expected [10.0.0.2], got %v", results2)
 		}
 
-		// Query for garage hostname (not in any indexer)
-		results3, _ := lookup([]string{"garage.example.com"})
+		results3, _ := lookup([]string{"service3-fe.example.com"})
 		if len(results3) != 0 {
-			t.Errorf("expected no results for garage, got %v", results3)
+			t.Errorf("expected no results for service3-fe, got %v", results3)
 		}
 	})
 
 	t.Run("deduplication across overlapping informers", func(t *testing.T) {
-		// Add the same service to both indexers to verify dedup
-		if err := indexer2.Add(kitchenFrontend); err != nil {
+		if err := indexer2.Add(service1Frontend); err != nil {
 			t.Fatalf("failed to add duplicate: %v", err)
 		}
-		results, _ := lookup([]string{"kitchen-fe.example.com"})
+		results, _ := lookup([]string{"service1-fe.example.com"})
 		if len(results) != 1 {
 			t.Errorf("expected 1 result after dedup, got %d: %v", len(results), results)
 		}

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -692,13 +692,13 @@ func (f *fakeSharedIndexInformer) GetIndexer() cache.Indexer { return f.indexer 
 func TestServiceLabelSelector(t *testing.T) {
 	ctx := context.TODO()
 
-	prodService := &core.Service{
+	service1 := &core.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "svc-prod",
+			Name:      "service1",
 			Namespace: "default",
-			Labels:    map[string]string{"env": "prod", "tier": "frontend"},
+			Labels:    map[string]string{"app": "service1", "tier": "frontend"},
 			Annotations: map[string]string{
-				hostnameAnnotationKey: "prod.example.com",
+				hostnameAnnotationKey: "service1.example.com",
 			},
 		},
 		Spec: core.ServiceSpec{Type: core.ServiceTypeLoadBalancer},
@@ -709,13 +709,13 @@ func TestServiceLabelSelector(t *testing.T) {
 		},
 	}
 
-	stagingService := &core.Service{
+	service2 := &core.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "svc-staging",
+			Name:      "service2",
 			Namespace: "default",
-			Labels:    map[string]string{"env": "staging", "tier": "backend"},
+			Labels:    map[string]string{"app": "service2", "tier": "backend"},
 			Annotations: map[string]string{
-				hostnameAnnotationKey: "staging.example.com",
+				hostnameAnnotationKey: "service2.example.com",
 			},
 		},
 		Spec: core.ServiceSpec{Type: core.ServiceTypeLoadBalancer},
@@ -726,12 +726,12 @@ func TestServiceLabelSelector(t *testing.T) {
 		},
 	}
 
-	unlabeledService := &core.Service{
+	service3 := &core.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "svc-unlabeled",
+			Name:      "service3",
 			Namespace: "default",
 			Annotations: map[string]string{
-				hostnameAnnotationKey: "unlabeled.example.com",
+				hostnameAnnotationKey: "service3.example.com",
 			},
 		},
 		Spec: core.ServiceSpec{Type: core.ServiceTypeLoadBalancer},
@@ -752,43 +752,43 @@ func TestServiceLabelSelector(t *testing.T) {
 			name:          "empty selector returns all services",
 			selector:      "",
 			expectedCount: 3,
-			expectedNames: []string{"svc-prod", "svc-staging", "svc-unlabeled"},
+			expectedNames: []string{"service1", "service2", "service3"},
 		},
 		{
 			name:          "equality selector matches one service",
-			selector:      "env=prod",
+			selector:      "app=service1",
 			expectedCount: 1,
-			expectedNames: []string{"svc-prod"},
+			expectedNames: []string{"service1"},
 		},
 		{
 			name:          "set-based selector matches multiple services",
-			selector:      "env in (prod,staging)",
+			selector:      "app in (service1,service2)",
 			expectedCount: 2,
-			expectedNames: []string{"svc-prod", "svc-staging"},
+			expectedNames: []string{"service1", "service2"},
 		},
 		{
 			name:          "selector with no matches returns empty",
-			selector:      "env=dev",
+			selector:      "app=service4",
 			expectedCount: 0,
 			expectedNames: []string{},
 		},
 		{
 			name:          "compound selector narrows results",
-			selector:      "env=prod,tier=frontend",
+			selector:      "app=service1,tier=frontend",
 			expectedCount: 1,
-			expectedNames: []string{"svc-prod"},
+			expectedNames: []string{"service1"},
 		},
 		{
 			name:          "inequality selector excludes matching value",
-			selector:      "env!=staging",
+			selector:      "app!=service2",
 			expectedCount: 2,
-			expectedNames: []string{"svc-prod", "svc-unlabeled"},
+			expectedNames: []string{"service1", "service3"},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			client := fake.NewClientset(prodService, stagingService, unlabeledService)
+			client := fake.NewClientset(service1, service2, service3)
 
 			lister := serviceLister(ctx, client, core.NamespaceAll, tc.selector)
 			result, err := lister(metav1.ListOptions{})
@@ -826,13 +826,13 @@ func TestServiceLabelSelector(t *testing.T) {
 }
 
 func TestMultiSelectorServiceLookup(t *testing.T) {
-	service1Frontend := &core.Service{
+	service1 := &core.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "service1-fe",
+			Name:      "service1",
 			Namespace: "default",
-			Labels:    map[string]string{"app": "service1", "tier": "frontend"},
+			Labels:    map[string]string{"app": "service1"},
 			Annotations: map[string]string{
-				hostnameAnnotationKey: "service1-fe.example.com",
+				hostnameAnnotationKey: "service1.example.com",
 			},
 		},
 		Spec: core.ServiceSpec{Type: core.ServiceTypeLoadBalancer},
@@ -843,13 +843,13 @@ func TestMultiSelectorServiceLookup(t *testing.T) {
 		},
 	}
 
-	service2Backend := &core.Service{
+	service2 := &core.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "service2-be",
+			Name:      "service2",
 			Namespace: "default",
-			Labels:    map[string]string{"app": "service2", "tier": "backend"},
+			Labels:    map[string]string{"app": "service2"},
 			Annotations: map[string]string{
-				hostnameAnnotationKey: "service2-be.example.com",
+				hostnameAnnotationKey: "service2.example.com",
 			},
 		},
 		Spec: core.ServiceSpec{Type: core.ServiceTypeLoadBalancer},
@@ -860,13 +860,13 @@ func TestMultiSelectorServiceLookup(t *testing.T) {
 		},
 	}
 
-	service3Frontend := &core.Service{
+	service3 := &core.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "service3-fe",
+			Name:      "service3",
 			Namespace: "default",
-			Labels:    map[string]string{"app": "service3", "tier": "frontend"},
+			Labels:    map[string]string{"app": "service3"},
 			Annotations: map[string]string{
-				hostnameAnnotationKey: "service3-fe.example.com",
+				hostnameAnnotationKey: "service3.example.com",
 			},
 		},
 		Spec: core.ServiceSpec{Type: core.ServiceTypeLoadBalancer},
@@ -877,27 +877,24 @@ func TestMultiSelectorServiceLookup(t *testing.T) {
 		},
 	}
 
-	// Build two indexers with disjoint selectors, simulating what kubernetes.go
-	// does when multiple serviceLabelSelectors are configured.
-	// Selector 1: app=service1,tier=frontend -> matches service1Frontend
-	// Selector 2: app=service2,tier=backend  -> matches service2Backend
-	// service3Frontend matches neither.
+	// Two indexers with disjoint selectors: app=service1 and app=service2.
+	// service3 matches neither.
 
 	indexer1 := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
 		serviceHostnameIndex: serviceHostnameIndexFunc,
 	})
-	if err := indexer1.Add(service1Frontend); err != nil {
+	if err := indexer1.Add(service1); err != nil {
 		t.Fatalf("failed to add service to indexer1: %v", err)
 	}
 
 	indexer2 := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
 		serviceHostnameIndex: serviceHostnameIndexFunc,
 	})
-	if err := indexer2.Add(service2Backend); err != nil {
+	if err := indexer2.Add(service2); err != nil {
 		t.Fatalf("failed to add service to indexer2: %v", err)
 	}
 
-	_ = service3Frontend // not added to any indexer
+	_ = service3 // not added to any indexer
 
 	controllers := []cache.SharedIndexInformer{
 		&fakeSharedIndexInformer{indexer: indexer1},
@@ -907,27 +904,27 @@ func TestMultiSelectorServiceLookup(t *testing.T) {
 	lookup := lookupServiceIndex(controllers)
 
 	t.Run("union of disjoint selectors returns both services", func(t *testing.T) {
-		results1, _ := lookup([]string{"service1-fe.example.com"})
+		results1, _ := lookup([]string{"service1.example.com"})
 		if len(results1) != 1 || results1[0].String() != "10.0.0.1" {
 			t.Errorf("expected [10.0.0.1], got %v", results1)
 		}
 
-		results2, _ := lookup([]string{"service2-be.example.com"})
+		results2, _ := lookup([]string{"service2.example.com"})
 		if len(results2) != 1 || results2[0].String() != "10.0.0.2" {
 			t.Errorf("expected [10.0.0.2], got %v", results2)
 		}
 
-		results3, _ := lookup([]string{"service3-fe.example.com"})
+		results3, _ := lookup([]string{"service3.example.com"})
 		if len(results3) != 0 {
-			t.Errorf("expected no results for service3-fe, got %v", results3)
+			t.Errorf("expected no results for service3, got %v", results3)
 		}
 	})
 
 	t.Run("deduplication across overlapping informers", func(t *testing.T) {
-		if err := indexer2.Add(service1Frontend); err != nil {
+		if err := indexer2.Add(service1); err != nil {
 			t.Fatalf("failed to add duplicate: %v", err)
 		}
-		results, _ := lookup([]string{"service1-fe.example.com"})
+		results, _ := lookup([]string{"service1.example.com"})
 		if len(results) != 1 {
 			t.Errorf("expected 1 result after dedup, got %d: %v", len(results), results)
 		}

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -688,3 +688,139 @@ type fakeSharedIndexInformer struct {
 }
 
 func (f *fakeSharedIndexInformer) GetIndexer() cache.Indexer { return f.indexer }
+
+func TestServiceLabelSelector(t *testing.T) {
+	ctx := context.TODO()
+
+	prodService := &core.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc-prod",
+			Namespace: "default",
+			Labels:    map[string]string{"env": "prod", "tier": "frontend"},
+			Annotations: map[string]string{
+				hostnameAnnotationKey: "prod.example.com",
+			},
+		},
+		Spec: core.ServiceSpec{Type: core.ServiceTypeLoadBalancer},
+		Status: core.ServiceStatus{
+			LoadBalancer: core.LoadBalancerStatus{
+				Ingress: []core.LoadBalancerIngress{{IP: "10.0.0.1"}},
+			},
+		},
+	}
+
+	stagingService := &core.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc-staging",
+			Namespace: "default",
+			Labels:    map[string]string{"env": "staging", "tier": "backend"},
+			Annotations: map[string]string{
+				hostnameAnnotationKey: "staging.example.com",
+			},
+		},
+		Spec: core.ServiceSpec{Type: core.ServiceTypeLoadBalancer},
+		Status: core.ServiceStatus{
+			LoadBalancer: core.LoadBalancerStatus{
+				Ingress: []core.LoadBalancerIngress{{IP: "10.0.0.2"}},
+			},
+		},
+	}
+
+	unlabeledService := &core.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc-unlabeled",
+			Namespace: "default",
+			Annotations: map[string]string{
+				hostnameAnnotationKey: "unlabeled.example.com",
+			},
+		},
+		Spec: core.ServiceSpec{Type: core.ServiceTypeLoadBalancer},
+		Status: core.ServiceStatus{
+			LoadBalancer: core.LoadBalancerStatus{
+				Ingress: []core.LoadBalancerIngress{{IP: "10.0.0.3"}},
+			},
+		},
+	}
+
+	tests := []struct {
+		name          string
+		selector      string
+		expectedCount int
+		expectedNames []string
+	}{
+		{
+			name:          "empty selector returns all services",
+			selector:      "",
+			expectedCount: 3,
+			expectedNames: []string{"svc-prod", "svc-staging", "svc-unlabeled"},
+		},
+		{
+			name:          "equality selector matches one service",
+			selector:      "env=prod",
+			expectedCount: 1,
+			expectedNames: []string{"svc-prod"},
+		},
+		{
+			name:          "set-based selector matches multiple services",
+			selector:      "env in (prod,staging)",
+			expectedCount: 2,
+			expectedNames: []string{"svc-prod", "svc-staging"},
+		},
+		{
+			name:          "selector with no matches returns empty",
+			selector:      "env=dev",
+			expectedCount: 0,
+			expectedNames: []string{},
+		},
+		{
+			name:          "compound selector narrows results",
+			selector:      "env=prod,tier=frontend",
+			expectedCount: 1,
+			expectedNames: []string{"svc-prod"},
+		},
+		{
+			name:          "inequality selector excludes matching value",
+			selector:      "env!=staging",
+			expectedCount: 2,
+			expectedNames: []string{"svc-prod", "svc-unlabeled"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := fake.NewClientset(prodService, stagingService, unlabeledService)
+
+			lister := serviceLister(ctx, client, core.NamespaceAll, tc.selector)
+			result, err := lister(metav1.ListOptions{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			serviceList, ok := result.(*core.ServiceList)
+			if !ok {
+				t.Fatalf("expected *core.ServiceList, got %T", result)
+			}
+
+			if len(serviceList.Items) != tc.expectedCount {
+				names := make([]string, len(serviceList.Items))
+				for i, svc := range serviceList.Items {
+					names[i] = svc.Name
+				}
+				t.Errorf("expected %d services, got %d: %v", tc.expectedCount, len(serviceList.Items), names)
+			}
+
+			for _, expectedName := range tc.expectedNames {
+				found := false
+				for _, svc := range serviceList.Items {
+					if svc.Name == expectedName {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected service %q not found in results", expectedName)
+				}
+			}
+		})
+	}
+}

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -592,7 +592,7 @@ var testNodes = map[string]*core.Node{
 	// ignored node — must not be indexed regardless of addresses
 	"ignored-node": {
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "ignored-node",
+			Name:   "ignored-node",
 			Labels: map[string]string{ignoreLabelKey: "true"},
 		},
 		Status: core.NodeStatus{
@@ -823,4 +823,117 @@ func TestServiceLabelSelector(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMultiSelectorServiceLookup(t *testing.T) {
+	kitchenFrontend := &core.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc-kitchen-fe",
+			Namespace: "default",
+			Labels:    map[string]string{"zone": "kitchen", "tier": "frontend"},
+			Annotations: map[string]string{
+				hostnameAnnotationKey: "kitchen-fe.example.com",
+			},
+		},
+		Spec: core.ServiceSpec{Type: core.ServiceTypeLoadBalancer},
+		Status: core.ServiceStatus{
+			LoadBalancer: core.LoadBalancerStatus{
+				Ingress: []core.LoadBalancerIngress{{IP: "10.0.0.1"}},
+			},
+		},
+	}
+
+	bedroomBackend := &core.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc-bedroom-be",
+			Namespace: "default",
+			Labels:    map[string]string{"zone": "bedroom", "tier": "backend"},
+			Annotations: map[string]string{
+				hostnameAnnotationKey: "bedroom-be.example.com",
+			},
+		},
+		Spec: core.ServiceSpec{Type: core.ServiceTypeLoadBalancer},
+		Status: core.ServiceStatus{
+			LoadBalancer: core.LoadBalancerStatus{
+				Ingress: []core.LoadBalancerIngress{{IP: "10.0.0.2"}},
+			},
+		},
+	}
+
+	garageService := &core.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc-garage",
+			Namespace: "default",
+			Labels:    map[string]string{"zone": "garage", "tier": "frontend"},
+			Annotations: map[string]string{
+				hostnameAnnotationKey: "garage.example.com",
+			},
+		},
+		Spec: core.ServiceSpec{Type: core.ServiceTypeLoadBalancer},
+		Status: core.ServiceStatus{
+			LoadBalancer: core.LoadBalancerStatus{
+				Ingress: []core.LoadBalancerIngress{{IP: "10.0.0.3"}},
+			},
+		},
+	}
+
+	// Build two indexers with disjoint selectors, simulating what kubernetes.go
+	// does when multiple serviceLabelSelectors are configured.
+	// Selector 1: zone=kitchen,tier=frontend -> matches kitchenFrontend
+	// Selector 2: zone=bedroom,tier=backend  -> matches bedroomBackend
+	// garageService matches neither.
+
+	indexer1 := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		serviceHostnameIndex: serviceHostnameIndexFunc,
+	})
+	if err := indexer1.Add(kitchenFrontend); err != nil {
+		t.Fatalf("failed to add service to indexer1: %v", err)
+	}
+
+	indexer2 := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		serviceHostnameIndex: serviceHostnameIndexFunc,
+	})
+	if err := indexer2.Add(bedroomBackend); err != nil {
+		t.Fatalf("failed to add service to indexer2: %v", err)
+	}
+
+	_ = garageService // not added to any indexer
+
+	controllers := []cache.SharedIndexInformer{
+		&fakeSharedIndexInformer{indexer: indexer1},
+		&fakeSharedIndexInformer{indexer: indexer2},
+	}
+
+	lookup := lookupServiceIndex(controllers)
+
+	t.Run("union of disjoint selectors returns both services", func(t *testing.T) {
+		// Query for kitchen-fe hostname
+		results1, _ := lookup([]string{"kitchen-fe.example.com"})
+		if len(results1) != 1 || results1[0].String() != "10.0.0.1" {
+			t.Errorf("expected [10.0.0.1], got %v", results1)
+		}
+
+		// Query for bedroom-be hostname
+		results2, _ := lookup([]string{"bedroom-be.example.com"})
+		if len(results2) != 1 || results2[0].String() != "10.0.0.2" {
+			t.Errorf("expected [10.0.0.2], got %v", results2)
+		}
+
+		// Query for garage hostname (not in any indexer)
+		results3, _ := lookup([]string{"garage.example.com"})
+		if len(results3) != 0 {
+			t.Errorf("expected no results for garage, got %v", results3)
+		}
+	})
+
+	t.Run("deduplication across overlapping informers", func(t *testing.T) {
+		// Add the same service to both indexers to verify dedup
+		if err := indexer2.Add(kitchenFrontend); err != nil {
+			t.Fatalf("failed to add duplicate: %v", err)
+		}
+		results, _ := lookup([]string{"kitchen-fe.example.com"})
+		if len(results) != 1 {
+			t.Errorf("expected 1 result after dedup, got %d: %v", len(results), results)
+		}
+	})
 }

--- a/setup.go
+++ b/setup.go
@@ -8,6 +8,7 @@ import (
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
 	clog "github.com/coredns/coredns/plugin/pkg/log"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 var (
@@ -119,6 +120,16 @@ func parse(c *caddy.Controller) (*Gateway, error) {
 					return nil, c.Errf("Incorrectly formatted 'gatewayClasses' parameter")
 				}
 				gw.resourceFilters.gatewayClasses = args
+
+			case "serviceLabelSelector":
+				args := c.RemainingArgs()
+				if len(args) != 1 {
+					return nil, c.Errf("serviceLabelSelector requires exactly one argument (a label selector string)")
+				}
+				if _, err := labels.Parse(args[0]); err != nil {
+					return nil, c.Errf("invalid serviceLabelSelector: %v", err)
+				}
+				gw.resourceFilters.serviceLabelSelector = args[0]
 
 			case "nodeAddressType":
 				args := c.RemainingArgs()

--- a/setup.go
+++ b/setup.go
@@ -127,6 +127,9 @@ func parse(c *caddy.Controller) (*Gateway, error) {
 					return nil, c.Errf("serviceLabelSelectors requires at least one argument (a label selector string)")
 				}
 				for _, arg := range args {
+					if arg == "" {
+						return nil, c.Errf("serviceLabelSelectors does not accept empty strings")
+					}
 					sel, err := labels.Parse(arg)
 					if err != nil {
 						return nil, c.Errf("invalid serviceLabelSelectors %q: %v", arg, err)

--- a/setup.go
+++ b/setup.go
@@ -121,15 +121,18 @@ func parse(c *caddy.Controller) (*Gateway, error) {
 				}
 				gw.resourceFilters.gatewayClasses = args
 
-			case "serviceLabelSelector":
+			case "serviceLabelSelectors":
 				args := c.RemainingArgs()
-				if len(args) != 1 {
-					return nil, c.Errf("serviceLabelSelector requires exactly one argument (a label selector string)")
+				if len(args) == 0 {
+					return nil, c.Errf("serviceLabelSelectors requires at least one argument (a label selector string)")
 				}
-				if _, err := labels.Parse(args[0]); err != nil {
-					return nil, c.Errf("invalid serviceLabelSelector: %v", err)
+				for _, arg := range args {
+					sel, err := labels.Parse(arg)
+					if err != nil {
+						return nil, c.Errf("invalid serviceLabelSelectors %q: %v", arg, err)
+					}
+					gw.resourceFilters.serviceLabelSelectors = append(gw.resourceFilters.serviceLabelSelectors, sel.String())
 				}
-				gw.resourceFilters.serviceLabelSelector = args[0]
 
 			case "nodeAddressType":
 				args := c.RemainingArgs()

--- a/setup_test.go
+++ b/setup_test.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/coredns/caddy"
@@ -44,6 +45,7 @@ func TestServiceLabelSelectorParsing(t *testing.T) {
 	tests := []struct {
 		input             string
 		shouldErr         bool
+		expectedErr       string
 		expectedSelectors []string
 	}{
 		{
@@ -71,25 +73,29 @@ func TestServiceLabelSelectorParsing(t *testing.T) {
 			input: `k8s_gateway example.org {
 	serviceLabelSelectors
 }`,
-			shouldErr: true,
+			shouldErr:   true,
+			expectedErr: "requires at least one argument",
 		},
 		{
 			input: `k8s_gateway example.org {
 	serviceLabelSelectors "!!!invalid"
 }`,
-			shouldErr: true,
+			shouldErr:   true,
+			expectedErr: "invalid serviceLabelSelectors",
 		},
 		{
 			input: `k8s_gateway example.org {
 	serviceLabelSelectors ""
 }`,
-			shouldErr: true,
+			shouldErr:   true,
+			expectedErr: "does not accept empty strings",
 		},
 		{
 			input: `k8s_gateway example.org {
 	serviceLabelSelectors "" "app=service1"
 }`,
-			shouldErr: true,
+			shouldErr:   true,
+			expectedErr: "does not accept empty strings",
 		},
 		{
 			input: `k8s_gateway example.org {
@@ -121,6 +127,8 @@ func TestServiceLabelSelectorParsing(t *testing.T) {
 		if test.shouldErr {
 			if err == nil {
 				t.Errorf("Test %d: Expected error for input %s", i, test.input)
+			} else if test.expectedErr != "" && !strings.Contains(err.Error(), test.expectedErr) {
+				t.Errorf("Test %d: Expected error containing %q, got: %v", i, test.expectedErr, err)
 			}
 			continue
 		}

--- a/setup_test.go
+++ b/setup_test.go
@@ -39,3 +39,72 @@ func TestSetup(t *testing.T) {
 		}
 	}
 }
+
+func TestServiceLabelSelectorParsing(t *testing.T) {
+	tests := []struct {
+		input            string
+		shouldErr        bool
+		expectedSelector string
+	}{
+		{
+			input: `k8s_gateway example.org {
+	serviceLabelSelector "env=prod"
+}`,
+			shouldErr:        false,
+			expectedSelector: "env=prod",
+		},
+		{
+			input: `k8s_gateway example.org {
+	serviceLabelSelector "tier in (frontend,backend)"
+}`,
+			shouldErr:        false,
+			expectedSelector: "tier in (frontend,backend)",
+		},
+		{
+			input: `k8s_gateway example.org {
+	serviceLabelSelector "env=prod,tier!=cache"
+}`,
+			shouldErr:        false,
+			expectedSelector: "env=prod,tier!=cache",
+		},
+		{
+			input: `k8s_gateway example.org {
+	serviceLabelSelector
+}`,
+			shouldErr: true,
+		},
+		{
+			input: `k8s_gateway example.org {
+	serviceLabelSelector "!!!invalid"
+}`,
+			shouldErr: true,
+		},
+		{
+			input: `k8s_gateway example.org {
+	serviceLabelSelector "a=b" "c=d"
+}`,
+			shouldErr: true,
+		},
+	}
+
+	for i, test := range tests {
+		c := caddy.NewTestController("dns", test.input)
+		gw, err := parse(c)
+
+		if test.shouldErr {
+			if err == nil {
+				t.Errorf("Test %d: Expected error for input %s", i, test.input)
+			}
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("Test %d: Unexpected error for input %s: %v", i, test.input, err)
+			continue
+		}
+
+		if gw.resourceFilters.serviceLabelSelector != test.expectedSelector {
+			t.Errorf("Test %d: Expected selector %q, got %q", i, test.expectedSelector, gw.resourceFilters.serviceLabelSelector)
+		}
+	}
+}

--- a/setup_test.go
+++ b/setup_test.go
@@ -81,6 +81,18 @@ func TestServiceLabelSelectorParsing(t *testing.T) {
 		},
 		{
 			input: `k8s_gateway example.org {
+	serviceLabelSelectors ""
+}`,
+			shouldErr: true,
+		},
+		{
+			input: `k8s_gateway example.org {
+	serviceLabelSelectors "" "app=service1"
+}`,
+			shouldErr: true,
+		},
+		{
+			input: `k8s_gateway example.org {
 	serviceLabelSelectors "app=service1" "app=service2"
 }`,
 			shouldErr:         false,

--- a/setup_test.go
+++ b/setup_test.go
@@ -95,10 +95,10 @@ func TestServiceLabelSelectorParsing(t *testing.T) {
 		},
 		{
 			input: `k8s_gateway example.org {
-	serviceLabelSelectors "zone=kitchen,tier=frontend" "zone=bedroom,tier=backend"
+	serviceLabelSelectors "app=service1,tier=frontend" "app=service2,tier=backend"
 }`,
 			shouldErr:         false,
-			expectedSelectors: []string{"tier=frontend,zone=kitchen", "tier=backend,zone=bedroom"},
+			expectedSelectors: []string{"app=service1,tier=frontend", "app=service2,tier=backend"},
 		},
 	}
 

--- a/setup_test.go
+++ b/setup_test.go
@@ -42,48 +42,63 @@ func TestSetup(t *testing.T) {
 
 func TestServiceLabelSelectorParsing(t *testing.T) {
 	tests := []struct {
-		input            string
-		shouldErr        bool
-		expectedSelector string
+		input             string
+		shouldErr         bool
+		expectedSelectors []string
 	}{
 		{
 			input: `k8s_gateway example.org {
-	serviceLabelSelector "env=prod"
+	serviceLabelSelectors "env=prod"
 }`,
-			shouldErr:        false,
-			expectedSelector: "env=prod",
+			shouldErr:         false,
+			expectedSelectors: []string{"env=prod"},
 		},
 		{
 			input: `k8s_gateway example.org {
-	serviceLabelSelector "tier in (frontend,backend)"
+	serviceLabelSelectors "tier in (frontend,backend)"
 }`,
-			shouldErr:        false,
-			expectedSelector: "tier in (frontend,backend)",
+			shouldErr:         false,
+			expectedSelectors: []string{"tier in (backend,frontend)"},
 		},
 		{
 			input: `k8s_gateway example.org {
-	serviceLabelSelector "env=prod,tier!=cache"
+	serviceLabelSelectors "env=prod,tier!=cache"
 }`,
-			shouldErr:        false,
-			expectedSelector: "env=prod,tier!=cache",
+			shouldErr:         false,
+			expectedSelectors: []string{"env=prod,tier!=cache"},
 		},
 		{
 			input: `k8s_gateway example.org {
-	serviceLabelSelector
+	serviceLabelSelectors
 }`,
 			shouldErr: true,
 		},
 		{
 			input: `k8s_gateway example.org {
-	serviceLabelSelector "!!!invalid"
+	serviceLabelSelectors "!!!invalid"
 }`,
 			shouldErr: true,
 		},
 		{
 			input: `k8s_gateway example.org {
-	serviceLabelSelector "a=b" "c=d"
+	serviceLabelSelectors "a=b" "c=d"
 }`,
-			shouldErr: true,
+			shouldErr:         false,
+			expectedSelectors: []string{"a=b", "c=d"},
+		},
+		{
+			input: `k8s_gateway example.org {
+	serviceLabelSelectors "env = prod"
+}`,
+			shouldErr:         false,
+			expectedSelectors: []string{"env=prod"},
+		},
+		{
+			input: `k8s_gateway example.org {
+	serviceLabelSelectors "zone=kitchen,tier=frontend" "zone=bedroom,tier=backend"
+}`,
+			shouldErr:         false,
+			expectedSelectors: []string{"tier=frontend,zone=kitchen", "tier=backend,zone=bedroom"},
 		},
 	}
 
@@ -103,8 +118,14 @@ func TestServiceLabelSelectorParsing(t *testing.T) {
 			continue
 		}
 
-		if gw.resourceFilters.serviceLabelSelector != test.expectedSelector {
-			t.Errorf("Test %d: Expected selector %q, got %q", i, test.expectedSelector, gw.resourceFilters.serviceLabelSelector)
+		if len(gw.resourceFilters.serviceLabelSelectors) != len(test.expectedSelectors) {
+			t.Errorf("Test %d: Expected %d selectors, got %d: %v", i, len(test.expectedSelectors), len(gw.resourceFilters.serviceLabelSelectors), gw.resourceFilters.serviceLabelSelectors)
+			continue
+		}
+		for j, expected := range test.expectedSelectors {
+			if gw.resourceFilters.serviceLabelSelectors[j] != expected {
+				t.Errorf("Test %d: Selector %d: expected %q, got %q", i, j, expected, gw.resourceFilters.serviceLabelSelectors[j])
+			}
 		}
 	}
 }

--- a/setup_test.go
+++ b/setup_test.go
@@ -48,24 +48,24 @@ func TestServiceLabelSelectorParsing(t *testing.T) {
 	}{
 		{
 			input: `k8s_gateway example.org {
-	serviceLabelSelectors "env=prod"
+	serviceLabelSelectors "app=service1"
 }`,
 			shouldErr:         false,
-			expectedSelectors: []string{"env=prod"},
+			expectedSelectors: []string{"app=service1"},
 		},
 		{
 			input: `k8s_gateway example.org {
-	serviceLabelSelectors "tier in (frontend,backend)"
+	serviceLabelSelectors "app in (service1,service2)"
 }`,
 			shouldErr:         false,
-			expectedSelectors: []string{"tier in (backend,frontend)"},
+			expectedSelectors: []string{"app in (service1,service2)"},
 		},
 		{
 			input: `k8s_gateway example.org {
-	serviceLabelSelectors "env=prod,tier!=cache"
+	serviceLabelSelectors "app=service1,tier!=cache"
 }`,
 			shouldErr:         false,
-			expectedSelectors: []string{"env=prod,tier!=cache"},
+			expectedSelectors: []string{"app=service1,tier!=cache"},
 		},
 		{
 			input: `k8s_gateway example.org {
@@ -81,17 +81,17 @@ func TestServiceLabelSelectorParsing(t *testing.T) {
 		},
 		{
 			input: `k8s_gateway example.org {
-	serviceLabelSelectors "a=b" "c=d"
+	serviceLabelSelectors "app=service1" "app=service2"
 }`,
 			shouldErr:         false,
-			expectedSelectors: []string{"a=b", "c=d"},
+			expectedSelectors: []string{"app=service1", "app=service2"},
 		},
 		{
 			input: `k8s_gateway example.org {
-	serviceLabelSelectors "env = prod"
+	serviceLabelSelectors "app = service1"
 }`,
 			shouldErr:         false,
-			expectedSelectors: []string{"env=prod"},
+			expectedSelectors: []string{"app=service1"},
 		},
 		{
 			input: `k8s_gateway example.org {


### PR DESCRIPTION
## Summary

Adds a `serviceLabelSelectors` configuration directive that filters which `Service` resources are watched by a k8s_gateway instance, using standard Kubernetes label selector syntax. Multiple selectors can be specified; each creates a separate watch and results are merged with deduplication.

This enables split-horizon DNS setups where multiple k8s_gateway instances serve different network views, as well as OR-of-ANDs queries that a single Kubernetes label selector cannot express.

## Motivation

When running multiple k8s_gateway instances (one per network/zone), Services currently leak across DNS views. For example, given Services annotated with `coredns.io/hostname: app.example.com` in different zones (each with a zone-specific LoadBalancer IP), every k8s_gateway instance returns all IPs instead of only the one relevant to its zone.

The existing `gatewayClasses` and `ingressClasses` filters solve this for Gateway API and Ingress resources, but no equivalent existed for Services.

## Implementation

Filtering is applied at the Kubernetes API level by injecting each label selector into a dedicated Service ListWatch's `metav1.ListOptions.LabelSelector`. Non-matching Services are never fetched from the API, never deserialized, and never cached, making this the most efficient filtering approach.

When multiple selectors are provided, one informer is created per selector. `lookupServiceIndex` queries all informers and deduplicates results by namespace/name.

### Configuration

```
k8s_gateway example.com {
    serviceLabelSelectors "app=service1,tier=frontend" "app=service2,tier=backend"
}
```

Supports the full Kubernetes label selector grammar: equality (`app=service1`), inequality (`app!=service3`), set-based (`app in (service1,service2)`), and compound selectors (`app=service1,tier!=cache`). Selectors are normalized at parse time (e.g. `app = service1` becomes `app=service1`).

When omitted, behavior is unchanged (all Services are watched).

### Helm

```yaml
filters:
  serviceLabelSelectors:
    - "app=service1,tier=frontend"
    - "app=service2,tier=backend"
```

## Changes

- New `serviceLabelSelectors` config directive with parse-time validation and normalization
- API-level filtering via `ListOptions.LabelSelector` on Service ListWatch (one informer per selector)
- Union lookup with namespace/name deduplication across informers
- Helm chart support (bumped to 3.7.0), chart README parameter table updated
- Helm configmap unit tests (single selector, multiple selectors, empty/omitted)
- Go unit tests for parsing, normalization, filtering, and multi-selector union
- Project README updated

## Test plan

- [x] `go test ./...` passes with no regressions
- [x] `TestServiceLabelSelectorParsing` validates config parsing for valid/invalid inputs, multi-arg, and normalization
- [x] `TestServiceLabelSelector` validates API-level filtering with fake Kubernetes client
- [x] `TestMultiSelectorServiceLookup` validates union of disjoint selectors and deduplication across overlapping informers
- [x] Helm template renders correctly with multiple selectors, single selector, and empty (omitted)
- [x] `helm unittest` passes (29/29, including 3 new configmap tests)
- [x] Tested in a real-world cluster: confirmed that filtered instances only return matching Services instead of exposing the entire cluster's Services matching the domain (chart: `oci://docker.io/zadki3l/k8s-gateway:3.7.0`, image: `docker.io/zadki3l/k8s_gateway:feat_servicelabelselector_77d472d`)

---

*This PR was developed with assistance from Claude Code (Claude Opus 4.6). The design, architecture decisions, and code review were done by a human; Claude assisted with implementation, test writing, and documentation.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced support for filtering Kubernetes Service resources by multiple label selectors, enabling granular resource filtering where each selector establishes its own watch with results merged together.

* **Documentation**
  * Updated configuration reference documentation to describe the new service label selector filtering capability.

* **Tests**
  * Added comprehensive test coverage for label selector parsing and multi-selector service lookup functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->